### PR TITLE
Add client_event_id and SDK identification headers

### DIFF
--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -145,6 +145,32 @@ describe('MostlyGoodMetrics', () => {
       expect(events[0].platform).toBeDefined();
     });
 
+    it('should include client_event_id as a UUID', async () => {
+      MostlyGoodMetrics.track('test_event');
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const events = await storage.fetchEvents(1);
+      expect(events[0].client_event_id).toBeDefined();
+      // UUID v4 format: xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx
+      expect(events[0].client_event_id).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+      );
+    });
+
+    it('should generate unique client_event_id for each event', async () => {
+      MostlyGoodMetrics.track('event1');
+      MostlyGoodMetrics.track('event2');
+      MostlyGoodMetrics.track('event3');
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const events = await storage.fetchEvents(3);
+      const ids = events.map((e) => e.client_event_id);
+      const uniqueIds = new Set(ids);
+      expect(uniqueIds.size).toBe(3);
+    });
+
     it('should include $sdk property defaulting to javascript', async () => {
       MostlyGoodMetrics.track('test_event');
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -263,6 +263,7 @@ export class MostlyGoodMetrics {
 
     const event: MGMEvent = {
       name,
+      client_event_id: generateUUID(),
       timestamp: getISOTimestamp(),
       userId: this.userId ?? undefined,
       sessionId: this.sessionIdValue,

--- a/src/network.ts
+++ b/src/network.ts
@@ -7,9 +7,11 @@ import {
   ResolvedConfiguration,
   SendResult,
 } from './types';
+import { getOSVersion } from './utils';
 
 const EVENTS_ENDPOINT = '/v1/events';
 const REQUEST_TIMEOUT_MS = 60000; // 60 seconds
+const SDK_VERSION = '0.4.0';
 
 /**
  * Compress data using gzip if available (browser CompressionStream API).
@@ -72,9 +74,14 @@ export class FetchNetworkClient implements INetworkClient {
     const jsonBody = JSON.stringify(payload);
     const { data, compressed } = await compressIfNeeded(jsonBody);
 
+    const osVersion = config.osVersion || getOSVersion();
     const headers: Record<string, string> = {
       'Content-Type': 'application/json',
       'X-MGM-Key': config.apiKey,
+      'X-MGM-SDK': config.sdk,
+      'X-MGM-SDK-Version': SDK_VERSION,
+      'X-MGM-Platform': config.platform,
+      ...(osVersion && { 'X-MGM-Platform-Version': osVersion }),
     };
 
     if (config.bundleId) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -135,6 +135,11 @@ export interface MGMEvent {
   name: string;
 
   /**
+   * Unique client-generated ID for deduplication.
+   */
+  client_event_id: string;
+
+  /**
    * ISO8601 timestamp when the event occurred.
    */
   timestamp: string;


### PR DESCRIPTION
## Summary
- Add `client_event_id` (UUID) to events for deduplication
- Add SDK identification headers for Grafana metrics:
  - `X-MGM-SDK`: SDK name (javascript)
  - `X-MGM-SDK-Version`: SDK version (0.4.0)
  - `X-MGM-Platform`: Platform name (web)
  - `X-MGM-Platform-Version`: OS version
- Add tests for client_event_id uniqueness and format

## Test plan
- [x] All 86 tests pass
- [ ] Verify headers appear in server logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)