### PR TITLE
Add sdkVersion config option for wrapper SDKs

### DIFF
--- a/src/network.test.ts
+++ b/src/network.test.ts
@@ -64,12 +64,19 @@ describe('FetchNetworkClient', () => {
       expect(capturedHeaders['X-MGM-SDK']).toBe('react-native');
     });
 
-    it('should include X-MGM-SDK-Version header', async () => {
+    it('should include X-MGM-SDK-Version header with default version', async () => {
       const config = createMockConfig();
       await networkClient.sendEvents(createMockPayload(), config);
 
       expect(capturedHeaders['X-MGM-SDK-Version']).toBeDefined();
       expect(capturedHeaders['X-MGM-SDK-Version']).toMatch(/^\d+\.\d+\.\d+$/);
+    });
+
+    it('should use custom sdkVersion when provided', async () => {
+      const config = createMockConfig({ sdkVersion: '2.0.0' });
+      await networkClient.sendEvents(createMockPayload(), config);
+
+      expect(capturedHeaders['X-MGM-SDK-Version']).toBe('2.0.0');
     });
 
     it('should include X-MGM-Platform header from config', async () => {

--- a/src/network.ts
+++ b/src/network.ts
@@ -75,11 +75,12 @@ export class FetchNetworkClient implements INetworkClient {
     const { data, compressed } = await compressIfNeeded(jsonBody);
 
     const osVersion = config.osVersion || getOSVersion();
+    const sdkVersion = config.sdkVersion || SDK_VERSION;
     const headers: Record<string, string> = {
       'Content-Type': 'application/json',
       'X-MGM-Key': config.apiKey,
       'X-MGM-SDK': config.sdk,
-      'X-MGM-SDK-Version': SDK_VERSION,
+      'X-MGM-SDK-Version': sdkVersion,
       'X-MGM-Platform': config.platform,
       ...(osVersion && { 'X-MGM-Platform-Version': osVersion }),
     };

--- a/src/types.ts
+++ b/src/types.ts
@@ -86,6 +86,12 @@ export interface MGMConfiguration {
   sdk?: SDK;
 
   /**
+   * The SDK version string. Wrapper SDKs (e.g., React Native) should pass their version here.
+   * If not provided, uses the JS SDK's version.
+   */
+  sdkVersion?: string;
+
+  /**
    * Custom storage adapter. If not provided, uses localStorage in browsers
    * or in-memory storage in non-browser environments.
    */

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -180,6 +180,7 @@ export function resolveConfiguration(config: MGMConfiguration): ResolvedConfigur
     osVersion: config.osVersion ?? '',
     platform: config.platform ?? detectPlatform(),
     sdk: config.sdk ?? 'javascript',
+    sdkVersion: config.sdkVersion ?? '',
     storage: config.storage,
     networkClient: config.networkClient,
   };


### PR DESCRIPTION
## Summary
- Adds `sdkVersion` configuration option to `MGMConfiguration`
- Allows wrapper SDKs (e.g., React Native) to pass their own version number
- Version is sent in the `X-MGM-SDK-Version` header
- Falls back to JS SDK's default version if not provided

## Usage
```typescript
MostlyGoodMetrics.configure({
  apiKey: 'your-key',
  sdk: 'react-native',
  sdkVersion: '1.0.0',  // RN SDK version
  platform: Platform.OS,
});
```

## Test plan
- [x] Added test for custom sdkVersion being passed through
- [x] Existing tests pass
- [x] Coverage threshold met

🤖 Generated with [Claude Code](https://claude.com/claude-code)