### PR TITLE
Bump version to 0.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mostly-good-metrics/javascript",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mostly-good-metrics/javascript",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mostly-good-metrics/javascript",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "JavaScript/TypeScript SDK for MostlyGoodMetrics - a lightweight analytics library for web applications",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
- Add sdkVersion config option for wrapper SDKs ([#9](https://github.com/Mostly-Good-Metrics/mostly-good-metrics-js/pull/9))