### PR TITLE
Update default base URL to ingest.mostlygoodmetrics.com

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -10,7 +10,7 @@ export interface MGMConfiguration {
 
   /**
    * The base URL for the MostlyGoodMetrics API.
-   * @default "https://mostlygoodmetrics.com"
+   * @default "https://ingest.mostlygoodmetrics.com"
    */
   baseURL?: string;
 
@@ -369,7 +369,7 @@ export const SystemProperties = {
  * Default configuration values.
  */
 export const DefaultConfiguration = {
-  baseURL: 'https://mostlygoodmetrics.com',
+  baseURL: 'https://ingest.mostlygoodmetrics.com',
   environment: 'production',
   maxBatchSize: 100,
   flushInterval: 30,


### PR DESCRIPTION
## Summary
- Updates the default API endpoint from `mostlygoodmetrics.com` to `ingest.mostlygoodmetrics.com`
- Uses the dedicated ingestion endpoint for better reliability and separation of concerns
- This also affects the React Native SDK which uses the JavaScript SDK under the hood

## Test plan
- [ ] Verify SDK initializes correctly with new default endpoint
- [ ] Test event sending works with the new endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)