### PR TITLE
Bump version to 0.4.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mostly-good-metrics/javascript",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mostly-good-metrics/javascript",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mostly-good-metrics/javascript",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "JavaScript/TypeScript SDK for MostlyGoodMetrics - a lightweight analytics library for web applications",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
- Update default base URL to ingest.mostlygoodmetrics.com ([#11](https://github.com/Mostly-Good-Metrics/mostly-good-metrics-js/pull/11))