### PR TITLE
Add ruby 3.1 to mise.toml for Fastlane

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,3 @@
 [tools]
 node = "22"
+ruby = "3.1"


### PR DESCRIPTION
Adds ruby 3.1 to mise.toml so Fastlane can run locally.