### PR TITLE
Bump version to 0.4.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mostly-good-metrics/javascript",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mostly-good-metrics/javascript",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mostly-good-metrics/javascript",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "JavaScript/TypeScript SDK for MostlyGoodMetrics - a lightweight analytics library for web applications",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
- Use Authorization: Bearer header instead of X-MGM-Key ([#15](https://github.com/Mostly-Good-Metrics/mostly-good-metrics-js/pull/15))
- Add ruby 3.1 to mise.toml for Fastlane ([#14](https://github.com/Mostly-Good-Metrics/mostly-good-metrics-js/pull/14))
- Auto-create PR in RN repo to bump JS dependency after publish ([#13](https://github.com/Mostly-Good-Metrics/mostly-good-metrics-js/pull/13))
- Add CLAUDE.md with SDK development guidelines ([#3](https://github.com/Mostly-Good-Metrics/mostly-good-metrics-js/pull/3))