### PR TITLE
Use $anon_ prefix format for anonymous user IDs

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -16,6 +16,7 @@ import {
 import {
   delay,
   detectDeviceType,
+  generateAnonymousId,
   generateUUID,
   getDeviceModel,
   getISOTimestamp,
@@ -54,7 +55,10 @@ export class MostlyGoodMetrics {
 
     // Configure cookie settings before initializing anonymous ID
     persistence.configureCookies(config.cookieDomain, config.disableCookies);
-    this.anonymousIdValue = persistence.initializeAnonymousId(config.anonymousId, generateUUID);
+    this.anonymousIdValue = persistence.initializeAnonymousId(
+      config.anonymousId,
+      generateAnonymousId
+    );
 
     // Set up logging
     setDebugLogging(this.config.enableDebugLogging);

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,6 +65,7 @@ export { FetchNetworkClient, createDefaultNetworkClient } from './network';
 
 // Utilities (for advanced usage)
 export {
+  generateAnonymousId,
   generateUUID,
   getISOTimestamp,
   isValidEventName,

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,4 +1,5 @@
 import {
+  generateAnonymousId,
   generateUUID,
   getISOTimestamp,
   isValidEventName,
@@ -23,6 +24,26 @@ describe('generateUUID', () => {
       uuids.add(generateUUID());
     }
     expect(uuids.size).toBe(100);
+  });
+});
+
+describe('generateAnonymousId', () => {
+  it('should generate an ID with $anon_ prefix', () => {
+    const id = generateAnonymousId();
+    expect(id).toMatch(/^\$anon_[a-z0-9]{12}$/);
+  });
+
+  it('should generate unique IDs', () => {
+    const ids = new Set<string>();
+    for (let i = 0; i < 100; i++) {
+      ids.add(generateAnonymousId());
+    }
+    expect(ids.size).toBe(100);
+  });
+
+  it('should be 18 characters total ($anon_ + 12 random)', () => {
+    const id = generateAnonymousId();
+    expect(id.length).toBe(18);
   });
 });
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -30,6 +30,35 @@ export function generateUUID(): string {
 }
 
 /**
+ * Generate a short random string for anonymous IDs.
+ * Uses base36 (0-9, a-z) for URL-safe, readable IDs.
+ */
+function generateRandomString(length: number): string {
+  const chars = '0123456789abcdefghijklmnopqrstuvwxyz';
+  let result = '';
+  if (typeof crypto !== 'undefined' && crypto.getRandomValues) {
+    const array = new Uint8Array(length);
+    crypto.getRandomValues(array);
+    for (let i = 0; i < length; i++) {
+      result += chars[array[i] % chars.length];
+    }
+  } else {
+    for (let i = 0; i < length; i++) {
+      result += chars[Math.floor(Math.random() * chars.length)];
+    }
+  }
+  return result;
+}
+
+/**
+ * Generate an anonymous user ID with $anon_ prefix.
+ * Format: $anon_xxxxxxxxxxxx (12 random chars)
+ */
+export function generateAnonymousId(): string {
+  return `$anon_${generateRandomString(12)}`;
+}
+
+/**
  * Get the current timestamp in ISO8601 format.
  */
 export function getISOTimestamp(): string {


### PR DESCRIPTION
## Summary
- Changes anonymous ID format from UUID to `$anon_xxxxxxxxxxxx` (12 random alphanumeric chars)
- Provides a shorter, more readable format that's consistent across all SDKs

## Changes
- Add `generateAnonymousId()` function with `$anon_` prefix
- Add `generateRandomString()` helper using `crypto.getRandomValues`
- Update client to use new format for new users
- Add tests for anonymous ID generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)