### PR TITLE
Upload coverage to Covallaby

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,3 +65,11 @@ jobs:
         with:
           file: ./coverage/lcov.info
           fail_ci_if_error: false
+
+      - name: Upload coverage to Covallaby
+        if: github.event_name == 'push'
+        continue-on-error: true
+        run: |
+          curl -sf -X POST "https://app.covallaby.com/api/v1/upload?repo=${{ github.repository }}&branch=${{ github.ref_name }}&commit=${{ github.sha }}" \
+            -H "Authorization: Bearer ${{ secrets.COVALLABY_TOKEN }}" \
+            --data-binary @coverage/lcov.info


### PR DESCRIPTION
Adds a non-blocking `Upload coverage to Covallaby` step after the existing Codecov upload. On pushes to `main` it posts `coverage/lcov.info` to our hosted Covallaby instance so coverage history + the live badge stay current.

- `continue-on-error: true` — never blocks CI if the upload hiccups
- `if: github.event_name == 'push'` — only records real branch coverage, not fork PRs
- Uses the repo secret `COVALLABY_TOKEN` (already set)

Dashboard: https://app.covallaby.com/r/mostly-good-metrics/mostly-good-metrics-js

🤖 Generated with [Claude Code](https://claude.com/claude-code)