### PR TITLE
Upload PR coverage to Covallaby

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,9 +67,11 @@ jobs:
           fail_ci_if_error: false
 
       - name: Upload coverage to Covallaby
-        if: github.event_name == 'push'
+        if: ${{ !cancelled() }}
         continue-on-error: true
         run: |
-          curl -sf -X POST "https://app.covallaby.com/api/v1/upload?repo=${{ github.repository }}&branch=${{ github.ref_name }}&commit=${{ github.sha }}" \
+          URL="https://app.covallaby.com/api/v1/upload?repo=${{ github.repository }}&branch=${{ github.head_ref || github.ref_name }}&commit=${{ github.event.pull_request.head.sha || github.sha }}"
+          [ -n "${{ github.event.pull_request.number }}" ] && URL="${URL}&pr=${{ github.event.pull_request.number }}"
+          curl -sf -X POST "$URL" \
             -H "Authorization: Bearer ${{ secrets.COVALLABY_TOKEN }}" \
             --data-binary @coverage/lcov.info


### PR DESCRIPTION
Adds pull-request coverage uploads to Covallaby. Previously the `Upload coverage to Covallaby` step in `.github/workflows/ci.yml` only ran on `push` events. It now also runs on `pull_request` events, tagged with the PR number.

Changes to the single step:
- `if: ${{ !cancelled() }}` (was `github.event_name == 'push'`); `continue-on-error: true` preserved.
- URL now uses PR-aware branch (`github.head_ref || github.ref_name`) and commit (`github.event.pull_request.head.sha || github.sha`), and appends `&pr=<number>` when the event is a pull request.
- Coverage file path `coverage/lcov.info` preserved.

`on:` already includes `pull_request` (branches: [main]), so uploads will fire on PRs. No other steps touched. YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)