### PR TITLE
Add privacy controls: opt-out, DNT/GPC, anonymous ID reset, memory-only persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A lightweight JavaScript/TypeScript SDK for tracking analytics events with [Most
 - [Installation](#installation)
 - [Quick Start](#quick-start)
 - [User Identification](#user-identification)
+- [Privacy](#privacy)
 - [Configuration Options](#configuration-options)
 - [Automatic Events](#automatic-events)
 - [Automatic Properties](#automatic-properties)
@@ -119,6 +120,115 @@ When `disableCookies: true`:
 - No cookies are set
 - Cross-subdomain tracking is disabled
 
+See the [Privacy](#privacy) section for the full set of privacy controls (opt-out, Do Not Track, memory-only persistence, forget-me, and more).
+
+## Privacy
+
+The SDK ships with a full set of privacy controls: user-level opt-out, browser privacy signals (Do Not Track / Global Privacy Control), anonymous ID rotation and a full "forget me", reduced data collection, and configurable persistence including a memory-only mode.
+
+### Opt-out / opt-in
+
+```typescript
+MostlyGoodMetrics.optOut();      // Stop all tracking immediately
+MostlyGoodMetrics.isOptedOut();  // => true
+MostlyGoodMetrics.optIn();       // Resume tracking
+```
+
+- `optOut()` immediately stops tracking: `track()`, `identify()` and `flush()` become no-ops, and no network requests (including experiment fetches) are made.
+- Any queued (unsent) events are purged on opt-out, so nothing tracked before the call is ever sent.
+- The choice is persisted (localStorage + cookie, consistent with the anonymous ID) and survives page reloads. In `persistence: 'memory'` mode nothing is written, so the choice only lasts for the page session.
+- An explicit `optIn()` is also persisted and overrides `optedOutByDefault` and Do Not Track defaults on later visits.
+
+### Consent-first sites (`optedOutByDefault`)
+
+For sites that must not track before consent, start opted out and opt the user in once they consent:
+
+```typescript
+MostlyGoodMetrics.configure({
+  apiKey: 'mgm_proj_your_api_key',
+  optedOutByDefault: true,
+  persistence: 'memory', // optional: also avoid writing any IDs before consent
+});
+
+// Later, when the user consents:
+MostlyGoodMetrics.optIn();
+```
+
+A previously persisted `optIn()`/`optOut()` choice takes precedence over `optedOutByDefault`.
+
+> **Tip:** `optedOutByDefault` alone still persists an anonymous ID to localStorage/cookies. Combine it with `persistence: 'memory'` if nothing may be written before consent, then call `optIn()` after consent (note: with memory persistence the anonymous ID resets on every page load).
+
+### Do Not Track / Global Privacy Control (`respectDoNotTrack`)
+
+```typescript
+MostlyGoodMetrics.configure({
+  apiKey: 'mgm_proj_your_api_key',
+  respectDoNotTrack: true,
+});
+```
+
+When enabled, the SDK treats `navigator.doNotTrack === '1'` or `navigator.globalPrivacyControl === true` as opted out from initialization. Off by default. An explicit persisted `optIn()` takes precedence over the browser signal.
+
+### Resetting the anonymous ID / forget me
+
+```typescript
+// Rotate just the anonymous ID (returns the new ID)
+MostlyGoodMetrics.resetAnonymousId();
+
+// Standard logout: clear the user ID, keep the anonymous ID
+MostlyGoodMetrics.resetIdentity();
+
+// Full "forget me": also rotates the anonymous ID and purges local state
+MostlyGoodMetrics.resetIdentity({ clearAnonymousId: true });
+```
+
+`resetIdentity({ clearAnonymousId: true })` clears everything tied to the previous identity:
+
+- User ID and identify debounce state
+- Anonymous ID (rotated to a fresh one)
+- Queued (unsent) events
+- Super properties (including `$experiment_*` assignments)
+- Cached experiment variants and exposure dedup flags
+
+### Reduced data collection (`collectDeviceProperties`)
+
+```typescript
+MostlyGoodMetrics.configure({
+  apiKey: 'mgm_proj_your_api_key',
+  collectDeviceProperties: false,
+});
+```
+
+When `false`, the SDK omits `$device_type` and `$device_model` from event properties and `locale`/`timezone` from events and batch context. `platform`, `os_version` and `app_version` are still sent. Default: `true`.
+
+### Persistence modes (`persistence`)
+
+```typescript
+MostlyGoodMetrics.configure({
+  apiKey: 'mgm_proj_your_api_key',
+  persistence: 'memory', // 'localStorage+cookie' (default) | 'localStorage' | 'memory'
+});
+```
+
+| Mode | Anonymous ID | Event queue | Cookies | Survives reload |
+|------|--------------|-------------|---------|-----------------|
+| `'localStorage+cookie'` (default) | localStorage + cookie | localStorage | Yes (enables cross-subdomain tracking) | Yes |
+| `'localStorage'` | localStorage only | localStorage | No | Yes |
+| `'memory'` | In-memory only | In-memory only | No | No |
+
+In `'memory'` mode nothing is written to localStorage or cookies: the anonymous ID, event queue, super properties, opt-out flag and experiment cache all live in memory and are lost on reload. `disableCookies: true` keeps working as an alias for `persistence: 'localStorage'`; an explicit `persistence` option wins over `disableCookies`.
+
+### What the SDK collects automatically
+
+With default settings, every event includes:
+
+- **Identity**: `user_id` (identified ID or generated anonymous ID), `session_id` (per page load)
+- **Device** (disable with `collectDeviceProperties: false`): `$device_type`, `$device_model`, `locale`, `timezone`
+- **App/environment**: `platform`, `os_version`, `app_version` (if configured), `environment`, `$sdk`
+- **Metadata**: `client_event_id`, `timestamp`
+
+See [Automatic Properties](#automatic-properties) and [Automatic Context](#automatic-context) for the full reference. The SDK never reads or transmits anything beyond what is listed there plus the properties you pass explicitly.
+
 ## Configuration Options
 
 For more control, pass additional configuration:
@@ -152,7 +262,11 @@ MostlyGoodMetrics.configure({
 | `trackAppLifecycleEvents` | `false` | Auto-track lifecycle events ($app_opened, etc.) |
 | `bundleId` | auto-detected | Custom bundle identifier |
 | `cookieDomain` | - | Cookie domain for cross-subdomain tracking (e.g., `.example.com`) |
-| `disableCookies` | `false` | Disable cookies entirely (uses localStorage only) |
+| `disableCookies` | `false` | Disable cookies entirely (alias for `persistence: 'localStorage'`) |
+| `persistence` | `'localStorage+cookie'` | Where SDK state lives: `'localStorage+cookie'`, `'localStorage'`, or `'memory'` (see [Privacy](#privacy)) |
+| `optedOutByDefault` | `false` | Start opted out until `optIn()` is called (consent-first sites) |
+| `respectDoNotTrack` | `false` | Honor `navigator.doNotTrack` / Global Privacy Control as opt-out |
+| `collectDeviceProperties` | `true` | Collect `$device_type`, `$device_model`, `locale`, `timezone` |
 | `anonymousId` | auto-generated | Override anonymous ID (for wrapper SDKs) |
 | `storage` | auto-detected | Custom storage adapter (see [Custom Storage](#custom-storage)) |
 | `networkClient` | fetch-based | Custom network client |

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -1781,4 +1781,502 @@ describe('MostlyGoodMetrics', () => {
       });
     });
   });
+
+  describe('privacy controls', () => {
+    const OPT_OUT_KEY = 'mostlygoodmetrics_opt_out';
+    const ANONYMOUS_ID_KEY = 'mostlygoodmetrics_anonymous_id';
+
+    const clearCookie = (name: string) => {
+      document.cookie = `${name}=; path=/; max-age=0`;
+    };
+
+    const clearPersistedState = () => {
+      localStorage.clear();
+      clearCookie(OPT_OUT_KEY);
+      clearCookie(ANONYMOUS_ID_KEY);
+    };
+
+    const waitForAsync = () => new Promise((resolve) => setTimeout(resolve, 10));
+
+    beforeEach(() => {
+      clearPersistedState();
+    });
+
+    afterEach(() => {
+      clearPersistedState();
+    });
+
+    describe('optOut / optIn', () => {
+      beforeEach(() => {
+        MostlyGoodMetrics.configure({
+          apiKey: 'test-key',
+          storage,
+          networkClient,
+          trackAppLifecycleEvents: false,
+        });
+      });
+
+      it('should not be opted out by default', () => {
+        expect(MostlyGoodMetrics.isOptedOut()).toBe(false);
+      });
+
+      it('should stop tracking after optOut', async () => {
+        MostlyGoodMetrics.optOut();
+
+        MostlyGoodMetrics.track('after_opt_out');
+        await waitForAsync();
+
+        expect(MostlyGoodMetrics.isOptedOut()).toBe(true);
+        expect(await storage.eventCount()).toBe(0);
+      });
+
+      it('should purge queued events on optOut', async () => {
+        MostlyGoodMetrics.track('queued_event');
+        await waitForAsync();
+        expect(await storage.eventCount()).toBe(1);
+
+        MostlyGoodMetrics.optOut();
+        await waitForAsync();
+
+        expect(await storage.eventCount()).toBe(0);
+      });
+
+      it('should no-op identify while opted out', async () => {
+        MostlyGoodMetrics.optOut();
+
+        MostlyGoodMetrics.identify('user_123', { email: 'user@example.com' });
+        await waitForAsync();
+
+        expect(MostlyGoodMetrics.shared?.userId).toBeNull();
+        expect(await storage.eventCount()).toBe(0);
+      });
+
+      it('should no-op flush while opted out', async () => {
+        MostlyGoodMetrics.track('event_before');
+        await waitForAsync();
+
+        MostlyGoodMetrics.optOut();
+        await MostlyGoodMetrics.flush();
+
+        expect(networkClient.sentPayloads).toHaveLength(0);
+      });
+
+      it('should resume tracking after optIn', async () => {
+        MostlyGoodMetrics.optOut();
+        MostlyGoodMetrics.track('ignored');
+        await waitForAsync();
+        expect(await storage.eventCount()).toBe(0);
+
+        MostlyGoodMetrics.optIn();
+        MostlyGoodMetrics.track('tracked');
+        await waitForAsync();
+
+        expect(MostlyGoodMetrics.isOptedOut()).toBe(false);
+        expect(await storage.eventCount()).toBe(1);
+      });
+
+      it('should persist opt-out across a reload (new instance)', async () => {
+        MostlyGoodMetrics.optOut();
+        MostlyGoodMetrics.reset();
+
+        const freshStorage = new InMemoryEventStorage(100);
+        MostlyGoodMetrics.configure({
+          apiKey: 'test-key',
+          storage: freshStorage,
+          networkClient,
+          trackAppLifecycleEvents: false,
+        });
+
+        expect(MostlyGoodMetrics.isOptedOut()).toBe(true);
+
+        MostlyGoodMetrics.track('still_ignored');
+        await waitForAsync();
+        expect(await freshStorage.eventCount()).toBe(0);
+      });
+
+      it('should persist opt-out in localStorage', () => {
+        MostlyGoodMetrics.optOut();
+        expect(localStorage.getItem(OPT_OUT_KEY)).toBe('true');
+
+        MostlyGoodMetrics.optIn();
+        expect(localStorage.getItem(OPT_OUT_KEY)).toBe('false');
+      });
+
+      it('should return false from static isOptedOut when not configured', () => {
+        MostlyGoodMetrics.reset();
+        expect(MostlyGoodMetrics.isOptedOut()).toBe(false);
+      });
+    });
+
+    describe('optedOutByDefault', () => {
+      it('should start opted out when optedOutByDefault is true', async () => {
+        MostlyGoodMetrics.configure({
+          apiKey: 'test-key',
+          storage,
+          networkClient,
+          optedOutByDefault: true,
+          trackAppLifecycleEvents: false,
+        });
+
+        expect(MostlyGoodMetrics.isOptedOut()).toBe(true);
+
+        MostlyGoodMetrics.track('consent_first');
+        await waitForAsync();
+        expect(await storage.eventCount()).toBe(0);
+      });
+
+      it('should let a persisted optIn override optedOutByDefault', () => {
+        MostlyGoodMetrics.configure({
+          apiKey: 'test-key',
+          storage,
+          networkClient,
+          optedOutByDefault: true,
+          trackAppLifecycleEvents: false,
+        });
+        MostlyGoodMetrics.optIn();
+        MostlyGoodMetrics.reset();
+
+        MostlyGoodMetrics.configure({
+          apiKey: 'test-key',
+          storage: new InMemoryEventStorage(100),
+          networkClient,
+          optedOutByDefault: true,
+          trackAppLifecycleEvents: false,
+        });
+
+        expect(MostlyGoodMetrics.isOptedOut()).toBe(false);
+      });
+    });
+
+    describe('respectDoNotTrack', () => {
+      const setNavigatorValue = (property: string, value: unknown) => {
+        Object.defineProperty(window.navigator, property, {
+          value,
+          configurable: true,
+        });
+      };
+
+      afterEach(() => {
+        setNavigatorValue('doNotTrack', undefined);
+        setNavigatorValue('globalPrivacyControl', undefined);
+      });
+
+      it('should opt out when doNotTrack is "1" and respectDoNotTrack is true', async () => {
+        setNavigatorValue('doNotTrack', '1');
+
+        MostlyGoodMetrics.configure({
+          apiKey: 'test-key',
+          storage,
+          networkClient,
+          respectDoNotTrack: true,
+          trackAppLifecycleEvents: false,
+        });
+
+        expect(MostlyGoodMetrics.isOptedOut()).toBe(true);
+
+        MostlyGoodMetrics.track('dnt_event');
+        await waitForAsync();
+        expect(await storage.eventCount()).toBe(0);
+      });
+
+      it('should opt out when globalPrivacyControl is true and respectDoNotTrack is true', () => {
+        setNavigatorValue('globalPrivacyControl', true);
+
+        MostlyGoodMetrics.configure({
+          apiKey: 'test-key',
+          storage,
+          networkClient,
+          respectDoNotTrack: true,
+          trackAppLifecycleEvents: false,
+        });
+
+        expect(MostlyGoodMetrics.isOptedOut()).toBe(true);
+      });
+
+      it('should ignore doNotTrack when respectDoNotTrack is false (default)', () => {
+        setNavigatorValue('doNotTrack', '1');
+        setNavigatorValue('globalPrivacyControl', true);
+
+        MostlyGoodMetrics.configure({
+          apiKey: 'test-key',
+          storage,
+          networkClient,
+          trackAppLifecycleEvents: false,
+        });
+
+        expect(MostlyGoodMetrics.isOptedOut()).toBe(false);
+      });
+
+      it('should let a persisted optIn override the Do Not Track signal', () => {
+        setNavigatorValue('doNotTrack', '1');
+
+        MostlyGoodMetrics.configure({
+          apiKey: 'test-key',
+          storage,
+          networkClient,
+          respectDoNotTrack: true,
+          trackAppLifecycleEvents: false,
+        });
+        MostlyGoodMetrics.optIn();
+        MostlyGoodMetrics.reset();
+
+        MostlyGoodMetrics.configure({
+          apiKey: 'test-key',
+          storage: new InMemoryEventStorage(100),
+          networkClient,
+          respectDoNotTrack: true,
+          trackAppLifecycleEvents: false,
+        });
+
+        expect(MostlyGoodMetrics.isOptedOut()).toBe(false);
+      });
+    });
+
+    describe('resetAnonymousId', () => {
+      it('should generate and persist a new anonymous ID', () => {
+        const instance = MostlyGoodMetrics.configure({
+          apiKey: 'test-key',
+          storage,
+          networkClient,
+          trackAppLifecycleEvents: false,
+        });
+
+        const originalId = instance.anonymousId;
+        const newId = instance.resetAnonymousId();
+
+        expect(newId).not.toBe(originalId);
+        expect(newId).toMatch(/^\$anon_/);
+        expect(instance.anonymousId).toBe(newId);
+        expect(localStorage.getItem(ANONYMOUS_ID_KEY)).toBe(newId);
+      });
+
+      it('should return null from the static method when not configured', () => {
+        expect(MostlyGoodMetrics.resetAnonymousId()).toBeNull();
+      });
+    });
+
+    describe('resetIdentity({ clearAnonymousId: true })', () => {
+      let originalFetch: typeof global.fetch;
+
+      beforeEach(() => {
+        originalFetch = global.fetch;
+        global.fetch = jest.fn().mockResolvedValue({
+          ok: true,
+          json: async () => ({ assigned_variants: {} }),
+        }) as unknown as typeof global.fetch;
+      });
+
+      afterEach(() => {
+        global.fetch = originalFetch;
+      });
+
+      it('should keep the anonymous ID on a plain resetIdentity', () => {
+        const instance = MostlyGoodMetrics.configure({
+          apiKey: 'test-key',
+          storage,
+          networkClient,
+          trackAppLifecycleEvents: false,
+        });
+
+        const anonId = instance.anonymousId;
+        instance.identify('user_123');
+        instance.resetIdentity();
+
+        expect(instance.userId).toBeNull();
+        expect(instance.anonymousId).toBe(anonId);
+      });
+
+      it('should clear all identity and cached state (forget me)', async () => {
+        const instance = MostlyGoodMetrics.configure({
+          apiKey: 'test-key',
+          storage,
+          networkClient,
+          trackAppLifecycleEvents: false,
+        });
+
+        instance.identify('user_123', { email: 'user@example.com' });
+        instance.setSuperProperty('plan', 'pro');
+        instance.track('some_event');
+        await waitForAsync();
+
+        const originalAnonId = instance.anonymousId;
+        expect(await storage.eventCount()).toBeGreaterThan(0);
+
+        instance.resetIdentity({ clearAnonymousId: true });
+        await waitForAsync();
+
+        // User identity cleared
+        expect(instance.userId).toBeNull();
+        expect(localStorage.getItem('mostlygoodmetrics_user_id')).toBeNull();
+
+        // Anonymous ID rotated
+        expect(instance.anonymousId).not.toBe(originalAnonId);
+
+        // Queued events purged
+        expect(await storage.eventCount()).toBe(0);
+
+        // Super properties cleared
+        expect(instance.getSuperProperties()).toEqual({});
+
+        // Identify debounce state cleared
+        expect(localStorage.getItem('mostlygoodmetrics_identify_hash')).toBeNull();
+        expect(localStorage.getItem('mostlygoodmetrics_identify_timestamp')).toBeNull();
+
+        // Experiment cache no longer references the old identity
+        const cachedVariants = localStorage.getItem('mgm_experiment_variants');
+        if (cachedVariants) {
+          const parsed = JSON.parse(cachedVariants) as { userId: string };
+          expect(parsed.userId).not.toBe('user_123');
+          expect(parsed.userId).not.toBe(originalAnonId);
+        }
+
+        // Exposure dedup flags cleared
+        const exposures = localStorage.getItem('mgm_experiment_exposures');
+        expect([null, '', '[]']).toContain(exposures);
+      });
+    });
+
+    describe('persistence modes', () => {
+      it('should persist nothing in memory mode', async () => {
+        MostlyGoodMetrics.configure({
+          apiKey: 'test-key',
+          networkClient,
+          persistence: 'memory',
+          trackAppLifecycleEvents: false,
+        });
+        const instance = MostlyGoodMetrics.shared;
+        expect(instance).not.toBeNull();
+
+        instance?.track('memory_event');
+        instance?.setSuperProperty('plan', 'pro');
+        instance?.identify('memory_user');
+        instance?.optOut();
+        await waitForAsync();
+
+        // Anonymous ID exists but is not persisted anywhere
+        expect(instance?.anonymousId).toBeTruthy();
+
+        const mgmKeys = Object.keys(localStorage).filter((key) =>
+          key.startsWith('mostlygoodmetrics')
+        );
+        expect(mgmKeys).toEqual([]);
+        expect(document.cookie).not.toContain('mostlygoodmetrics');
+      });
+
+      it('should keep the in-session opt-out choice without writing it anywhere in memory mode', () => {
+        MostlyGoodMetrics.configure({
+          apiKey: 'test-key',
+          networkClient,
+          persistence: 'memory',
+          trackAppLifecycleEvents: false,
+        });
+        MostlyGoodMetrics.optOut();
+        MostlyGoodMetrics.reset();
+
+        // Within the same JS session the in-memory choice is retained
+        // (a real page reload starts fresh - nothing durable was written)
+        MostlyGoodMetrics.configure({
+          apiKey: 'test-key',
+          networkClient,
+          persistence: 'memory',
+          trackAppLifecycleEvents: false,
+        });
+
+        expect(MostlyGoodMetrics.isOptedOut()).toBe(true);
+        expect(localStorage.getItem(OPT_OUT_KEY)).toBeNull();
+        expect(document.cookie).not.toContain(OPT_OUT_KEY);
+      });
+
+      it('should keep disableCookies working as an alias for localStorage-only', () => {
+        MostlyGoodMetrics.configure({
+          apiKey: 'test-key',
+          storage,
+          networkClient,
+          disableCookies: true,
+          trackAppLifecycleEvents: false,
+        });
+
+        expect(MostlyGoodMetrics.shared?.configuration.persistence).toBe('localStorage');
+        expect(localStorage.getItem(ANONYMOUS_ID_KEY)).toBeTruthy();
+        expect(document.cookie).not.toContain(ANONYMOUS_ID_KEY);
+      });
+
+      it('should prefer an explicit persistence option over disableCookies', () => {
+        MostlyGoodMetrics.configure({
+          apiKey: 'test-key',
+          networkClient,
+          disableCookies: true,
+          persistence: 'memory',
+          trackAppLifecycleEvents: false,
+        });
+
+        expect(MostlyGoodMetrics.shared?.configuration.persistence).toBe('memory');
+      });
+    });
+
+    describe('collectDeviceProperties', () => {
+      it('should include device properties and locale context by default', async () => {
+        MostlyGoodMetrics.configure({
+          apiKey: 'test-key',
+          storage,
+          networkClient,
+          trackAppLifecycleEvents: false,
+        });
+
+        MostlyGoodMetrics.track('default_event');
+        await waitForAsync();
+
+        const events = await storage.fetchEvents(1);
+        expect(events[0].properties?.['$device_type']).toBeDefined();
+        expect(events[0].properties?.['$device_model']).toBeDefined();
+        expect(events[0].locale).toBeDefined();
+        expect(events[0].timezone).toBeDefined();
+      });
+
+      it('should omit device properties and locale context when disabled', async () => {
+        MostlyGoodMetrics.configure({
+          apiKey: 'test-key',
+          storage,
+          networkClient,
+          collectDeviceProperties: false,
+          appVersion: '1.2.3',
+          trackAppLifecycleEvents: false,
+        });
+
+        MostlyGoodMetrics.track('minimal_event');
+        await waitForAsync();
+
+        const events = await storage.fetchEvents(1);
+        expect(events[0].properties?.['$device_type']).toBeUndefined();
+        expect(events[0].properties?.['$device_model']).toBeUndefined();
+        expect(events[0].locale).toBeUndefined();
+        expect(events[0].timezone).toBeUndefined();
+
+        // Platform, OS version and app version are still sent
+        // (detectPlatform resolves to 'node' under Jest)
+        expect(events[0].platform).toBeDefined();
+        expect(events[0].app_version).toBe('1.2.3');
+        expect(events[0].properties?.['$sdk']).toBe('javascript');
+      });
+
+      it('should omit locale and timezone from the flush context when disabled', async () => {
+        MostlyGoodMetrics.configure({
+          apiKey: 'test-key',
+          storage,
+          networkClient,
+          collectDeviceProperties: false,
+          trackAppLifecycleEvents: false,
+        });
+
+        MostlyGoodMetrics.track('context_event');
+        await waitForAsync();
+        await MostlyGoodMetrics.flush();
+
+        expect(networkClient.sentPayloads).toHaveLength(1);
+        expect(networkClient.sentPayloads[0].context.locale).toBeUndefined();
+        expect(networkClient.sentPayloads[0].context.timezone).toBeUndefined();
+        expect(networkClient.sentPayloads[0].context.platform).toBeDefined();
+      });
+    });
+  });
 });

--- a/src/client.ts
+++ b/src/client.ts
@@ -12,6 +12,7 @@ import {
   MGMEvent,
   MGMEventContext,
   MGMEventsPayload,
+  ResetIdentityOptions,
   ResolvedConfiguration,
   SystemEvents,
   SystemProperties,
@@ -27,6 +28,7 @@ import {
   getLocale,
   getOSVersion,
   getTimezone,
+  isDoNotTrackEnabled,
   resolveConfiguration,
   sanitizeProperties,
   validateEventName,
@@ -54,6 +56,7 @@ export class MostlyGoodMetrics {
   private sessionIdValue: string;
   private anonymousIdValue: string;
   private lifecycleSetup = false;
+  private optedOut: boolean;
 
   // A/B testing state
   private assignedVariants: Record<string, string> = {}; // Server-assigned variants
@@ -70,24 +73,48 @@ export class MostlyGoodMetrics {
     this.config = resolveConfiguration(config);
     this.sessionIdValue = generateUUID();
 
-    // Configure cookie settings before initializing anonymous ID
-    persistence.configureCookies(config.cookieDomain, config.disableCookies);
+    // Configure persistence settings before initializing anonymous ID.
+    // `disableCookies` is honored as an alias for persistence: 'localStorage'
+    // during configuration resolution.
+    persistence.configurePersistence(this.config.persistence, config.cookieDomain);
     this.anonymousIdValue = persistence.initializeAnonymousId(
       config.anonymousId,
       generateAnonymousId
     );
 
+    // Resolve the opt-out state:
+    // 1. An explicit persisted optOut()/optIn() choice always wins.
+    // 2. Otherwise `optedOutByDefault` (consent-first sites).
+    // 3. Otherwise browser privacy signals, when `respectDoNotTrack` is on.
+    const storedOptOut = persistence.getOptOutStatus();
+    if (storedOptOut !== null) {
+      this.optedOut = storedOptOut;
+    } else if (this.config.optedOutByDefault) {
+      this.optedOut = true;
+    } else if (this.config.respectDoNotTrack && isDoNotTrackEnabled()) {
+      this.optedOut = true;
+    } else {
+      this.optedOut = false;
+    }
+
     // Set up logging
     setDebugLogging(this.config.enableDebugLogging);
 
+    if (this.optedOut) {
+      logger.info('Tracking is disabled (opted out)');
+    }
+
     // Initialize storage
-    this.storage = this.config.storage ?? createDefaultStorage(this.config.maxStoredEvents);
+    this.storage =
+      this.config.storage ??
+      createDefaultStorage(this.config.maxStoredEvents, this.config.persistence);
 
     // Initialize network client
     this.networkClient = this.config.networkClient ?? createDefaultNetworkClient();
 
     // Initialize experiment storage (pluggable for React Native AsyncStorage etc.)
-    this.experimentStorage = this.config.experimentStorage ?? createDefaultExperimentStorage();
+    this.experimentStorage =
+      this.config.experimentStorage ?? createDefaultExperimentStorage(this.config.persistence);
 
     // Initialize experiments ready promise
     this.experimentsReadyPromise = new Promise((resolve) => {
@@ -175,9 +202,44 @@ export class MostlyGoodMetrics {
 
   /**
    * Reset user identity.
+   * Pass `{ clearAnonymousId: true }` for a full "forget me" that also
+   * rotates the anonymous ID, purges queued events, super properties,
+   * identify debounce state and the cached experiment variants.
    */
-  static resetIdentity(): void {
-    MostlyGoodMetrics.instance?.resetIdentity();
+  static resetIdentity(options?: ResetIdentityOptions): void {
+    MostlyGoodMetrics.instance?.resetIdentity(options);
+  }
+
+  /**
+   * Reset the anonymous ID to a newly generated one.
+   * Returns the new anonymous ID, or null if the SDK is not configured.
+   */
+  static resetAnonymousId(): string | null {
+    return MostlyGoodMetrics.instance?.resetAnonymousId() ?? null;
+  }
+
+  /**
+   * Opt the current user out of all tracking.
+   * Persisted across reloads; also purges any queued (unsent) events.
+   */
+  static optOut(): void {
+    MostlyGoodMetrics.instance?.optOut();
+  }
+
+  /**
+   * Opt the current user back in to tracking.
+   * Persisted across reloads.
+   */
+  static optIn(): void {
+    MostlyGoodMetrics.instance?.optIn();
+  }
+
+  /**
+   * Check whether tracking is currently opted out.
+   * Returns false if the SDK is not configured.
+   */
+  static isOptedOut(): boolean {
+    return MostlyGoodMetrics.instance?.isOptedOut() ?? false;
   }
 
   /**
@@ -311,6 +373,11 @@ export class MostlyGoodMetrics {
    * Track an event with the given name and optional properties.
    */
   track(name: string, properties?: EventProperties): void {
+    if (this.optedOut) {
+      logger.debug(`Tracking is opted out, ignoring event: ${name}`);
+      return;
+    }
+
     try {
       validateEventName(name);
     } catch (e) {
@@ -326,8 +393,12 @@ export class MostlyGoodMetrics {
     const mergedProperties: EventProperties = {
       ...superProperties,
       ...sanitizedProperties,
-      [SystemProperties.DEVICE_TYPE]: detectDeviceType(),
-      [SystemProperties.DEVICE_MODEL]: getDeviceModel(),
+      ...(this.config.collectDeviceProperties
+        ? {
+            [SystemProperties.DEVICE_TYPE]: detectDeviceType(),
+            [SystemProperties.DEVICE_MODEL]: getDeviceModel(),
+          }
+        : {}),
       [SystemProperties.SDK]: this.config.sdk,
     };
 
@@ -343,8 +414,8 @@ export class MostlyGoodMetrics {
       app_version: this.config.appVersion || undefined,
       os_version: this.config.osVersion || getOSVersion() || undefined,
       environment: this.config.environment,
-      locale: getLocale(),
-      timezone: getTimezone(),
+      locale: this.config.collectDeviceProperties ? getLocale() : undefined,
+      timezone: this.config.collectDeviceProperties ? getTimezone() : undefined,
       properties: Object.keys(mergedProperties).length > 0 ? mergedProperties : undefined,
     };
 
@@ -371,6 +442,11 @@ export class MostlyGoodMetrics {
    * @param profile Optional profile data (email, name)
    */
   identify(userId: string, profile?: UserProfile): void {
+    if (this.optedOut) {
+      logger.debug('Tracking is opted out, ignoring identify');
+      return;
+    }
+
     if (!userId) {
       logger.warn('identify called with empty userId');
       return;
@@ -457,11 +533,99 @@ export class MostlyGoodMetrics {
   /**
    * Reset user identity.
    * Clears the user ID and identify debounce state.
+   *
+   * Pass `{ clearAnonymousId: true }` for a full "forget me": additionally
+   * rotates the anonymous ID, purges queued (unsent) events, clears super
+   * properties and clears the cached experiment variants and exposure
+   * dedup flags, then refetches experiments for the fresh identity.
    */
-  resetIdentity(): void {
+  resetIdentity(options?: ResetIdentityOptions): void {
     logger.debug('Resetting user identity');
     persistence.setUserId(null);
     persistence.clearIdentifyState();
+
+    if (options?.clearAnonymousId) {
+      logger.debug('Performing full identity reset (forget me)');
+
+      // Rotate the anonymous ID
+      this.resetAnonymousId();
+
+      // Purge queued (unsent) events
+      this.storage.clear().catch((e) => {
+        logger.warn('Failed to clear queued events during identity reset', e);
+      });
+
+      // Clear super properties (including $experiment_* assignments)
+      persistence.clearSuperProperties();
+
+      // Clear in-memory and persisted experiment state
+      this.assignedVariants = {};
+      this.trackedExposures = new Set();
+      void this.clearExperimentsCache();
+
+      // Refetch experiments for the fresh identity (no-op while opted out)
+      this.resetExperimentsReadyPromise();
+      void this.fetchExperiments();
+    }
+  }
+
+  /**
+   * Reset the anonymous ID to a newly generated one and persist it.
+   * Returns the new anonymous ID.
+   *
+   * For a complete "forget me" (which also purges queued events, super
+   * properties and cached experiments), use
+   * `resetIdentity({ clearAnonymousId: true })`.
+   */
+  resetAnonymousId(): string {
+    const newId = persistence.resetAnonymousId(generateAnonymousId);
+    this.anonymousIdValue = newId;
+    logger.debug('Anonymous ID reset');
+    return newId;
+  }
+
+  /**
+   * Opt the current user out of all tracking.
+   *
+   * Immediately stops tracking (track/identify/flush become no-ops), purges
+   * any queued (unsent) events, and persists the choice so it survives
+   * reloads (except in `persistence: 'memory'` mode, where nothing is
+   * persisted).
+   */
+  optOut(): void {
+    logger.info('Opting out of tracking');
+    this.optedOut = true;
+    persistence.setOptOutStatus(true);
+
+    // Purge queued events so nothing tracked pre-opt-out is ever sent
+    this.storage.clear().catch((e) => {
+      logger.warn('Failed to clear queued events during opt-out', e);
+    });
+  }
+
+  /**
+   * Opt the current user back in to tracking.
+   * Persists the choice, overriding `optedOutByDefault` and Do Not Track
+   * defaults on later visits.
+   */
+  optIn(): void {
+    logger.info('Opting in to tracking');
+    const wasOptedOut = this.optedOut;
+    this.optedOut = false;
+    persistence.setOptOutStatus(false);
+
+    // Experiments are not fetched while opted out - fetch them now
+    if (wasOptedOut) {
+      this.resetExperimentsReadyPromise();
+      void this.fetchExperiments();
+    }
+  }
+
+  /**
+   * Check whether tracking is currently opted out.
+   */
+  isOptedOut(): boolean {
+    return this.optedOut;
   }
 
   /**
@@ -476,6 +640,11 @@ export class MostlyGoodMetrics {
    * Flush pending events to the server.
    */
   async flush(): Promise<void> {
+    if (this.optedOut) {
+      logger.debug('Tracking is opted out, skipping flush');
+      return;
+    }
+
     if (this.isFlushingInternal) {
       logger.debug('Flush already in progress');
       return;
@@ -694,8 +863,8 @@ export class MostlyGoodMetrics {
 
       session_id: this.sessionIdValue,
       environment: this.config.environment,
-      locale: getLocale(),
-      timezone: getTimezone(),
+      locale: this.config.collectDeviceProperties ? getLocale() : undefined,
+      timezone: this.config.collectDeviceProperties ? getTimezone() : undefined,
     };
 
     return { events, context };
@@ -879,6 +1048,13 @@ export class MostlyGoodMetrics {
    * still applied atomically - late variants are better than none.
    */
   private async fetchExperiments(): Promise<void> {
+    // No network requests while opted out. optIn() triggers a fetch.
+    if (this.optedOut) {
+      logger.debug('Tracking is opted out, skipping experiments fetch');
+      this.markExperimentsReady();
+      return;
+    }
+
     const currentUserId = this.userId ?? this.anonymousIdValue;
 
     // Build URL with user_id for server-side variant assignment.
@@ -1004,6 +1180,19 @@ export class MostlyGoodMetrics {
       );
     } catch (e) {
       logger.debug('Failed to persist experiment exposures', e);
+    }
+  }
+
+  /**
+   * Clear the persisted experiment variants cache and exposure dedup flags.
+   * Used by the full identity reset (forget me).
+   */
+  private async clearExperimentsCache(): Promise<void> {
+    try {
+      await this.experimentStorage.setItem(EXPERIMENTS_CACHE_KEY, '');
+      await this.experimentStorage.setItem(EXPERIMENT_EXPOSURES_KEY, '[]');
+    } catch (e) {
+      logger.debug('Failed to clear experiments cache', e);
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,8 @@ export type {
   MGMEventContext,
   MGMEventsPayload,
   Platform,
+  PersistenceMode,
+  ResetIdentityOptions,
   SDK,
   DeviceType,
   MGMErrorType,
@@ -89,6 +91,7 @@ export {
   detectDeviceType,
   getOSVersion,
   getDeviceModel,
+  isDoNotTrackEnabled,
 } from './utils';
 
 // Logger (for debugging)

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -6,6 +6,7 @@ import {
   IExperimentStorage,
   MGMError,
   MGMEvent,
+  PersistenceMode,
 } from './types';
 
 const STORAGE_KEY = 'mostlygoodmetrics_events';
@@ -15,6 +16,7 @@ const APP_VERSION_KEY = 'mostlygoodmetrics_app_version';
 const SUPER_PROPERTIES_KEY = 'mostlygoodmetrics_super_properties';
 const IDENTIFY_HASH_KEY = 'mostlygoodmetrics_identify_hash';
 const IDENTIFY_TIMESTAMP_KEY = 'mostlygoodmetrics_identify_timestamp';
+const OPT_OUT_KEY = 'mostlygoodmetrics_opt_out';
 
 /**
  * Check if we're running in a browser environment with localStorage available.
@@ -224,7 +226,15 @@ export class LocalStorageEventStorage implements IEventStorage {
 /**
  * Create the appropriate storage implementation based on the environment.
  */
-export function createDefaultStorage(maxEvents: number): IEventStorage {
+export function createDefaultStorage(
+  maxEvents: number,
+  mode: PersistenceMode = 'localStorage+cookie'
+): IEventStorage {
+  if (mode === 'memory') {
+    logger.debug('Memory persistence mode, using in-memory event storage');
+    return new InMemoryEventStorage(maxEvents);
+  }
+
   if (isLocalStorageAvailable()) {
     logger.debug('Using LocalStorage for event persistence');
     return new LocalStorageEventStorage(maxEvents);
@@ -277,8 +287,10 @@ export class InMemoryExperimentStorage implements IExperimentStorage {
  * React Native apps should inject an AsyncStorage-backed adapter via the
  * `experimentStorage` configuration option instead.
  */
-export function createDefaultExperimentStorage(): IExperimentStorage {
-  if (isLocalStorageAvailable()) {
+export function createDefaultExperimentStorage(
+  mode: PersistenceMode = 'localStorage+cookie'
+): IExperimentStorage {
+  if (mode !== 'memory' && isLocalStorageAvailable()) {
     return new LocalStorageExperimentStorage();
   }
   return new InMemoryExperimentStorage();
@@ -293,31 +305,53 @@ class PersistenceManager {
   private inMemoryAnonymousId: string | null = null;
   private inMemoryAppVersion: string | null = null;
   private inMemorySuperProperties: EventProperties = {};
+  private inMemoryOptOut: boolean | null = null;
+  private inMemoryIdentifyHash: string | null = null;
+  private inMemoryIdentifyLastSentAt: number | null = null;
   private cookieDomain: string | undefined = undefined;
-  private disableCookies = false;
+  private mode: PersistenceMode = 'localStorage+cookie';
 
   /**
-   * Configure cookie settings.
+   * Configure persistence settings.
+   * @param mode Where to persist state ('localStorage+cookie', 'localStorage', or 'memory')
+   * @param cookieDomain Domain for cross-subdomain cookies (e.g., '.example.com')
+   */
+  configurePersistence(mode: PersistenceMode, cookieDomain?: string): void {
+    this.mode = mode;
+    this.cookieDomain = cookieDomain;
+  }
+
+  /**
+   * Backwards-compatible cookie configuration.
    * @param cookieDomain Domain for cross-subdomain cookies (e.g., '.example.com')
    * @param disableCookies If true, only use localStorage (no cookies)
    */
   configureCookies(cookieDomain?: string, disableCookies?: boolean): void {
-    this.cookieDomain = cookieDomain;
-    this.disableCookies = disableCookies ?? false;
+    this.configurePersistence(
+      disableCookies ? 'localStorage' : 'localStorage+cookie',
+      cookieDomain
+    );
   }
 
   /**
    * Check if cookies should be used.
    */
   private shouldUseCookies(): boolean {
-    return !this.disableCookies && isCookieAvailable();
+    return this.mode === 'localStorage+cookie' && isCookieAvailable();
+  }
+
+  /**
+   * Check if localStorage should be used.
+   */
+  private shouldUseLocalStorage(): boolean {
+    return this.mode !== 'memory' && isLocalStorageAvailable();
   }
 
   /**
    * Get the persisted user ID.
    */
   getUserId(): string | null {
-    if (isLocalStorageAvailable()) {
+    if (this.shouldUseLocalStorage()) {
       return localStorage.getItem(USER_ID_KEY);
     }
     return this.inMemoryUserId;
@@ -327,7 +361,7 @@ class PersistenceManager {
    * Set the user ID (persists across sessions).
    */
   setUserId(userId: string | null): void {
-    if (isLocalStorageAvailable()) {
+    if (this.shouldUseLocalStorage()) {
       if (userId) {
         localStorage.setItem(USER_ID_KEY, userId);
       } else {
@@ -351,7 +385,7 @@ class PersistenceManager {
     }
 
     // Fall back to localStorage
-    if (isLocalStorageAvailable()) {
+    if (this.shouldUseLocalStorage()) {
       return localStorage.getItem(ANONYMOUS_ID_KEY);
     }
 
@@ -369,7 +403,7 @@ class PersistenceManager {
     }
 
     // Also save to localStorage as fallback
-    if (isLocalStorageAvailable()) {
+    if (this.shouldUseLocalStorage()) {
       localStorage.setItem(ANONYMOUS_ID_KEY, anonymousId);
     }
 
@@ -419,7 +453,7 @@ class PersistenceManager {
    * Get the persisted app version (for detecting updates).
    */
   getAppVersion(): string | null {
-    if (isLocalStorageAvailable()) {
+    if (this.shouldUseLocalStorage()) {
       return localStorage.getItem(APP_VERSION_KEY);
     }
     return this.inMemoryAppVersion;
@@ -429,7 +463,7 @@ class PersistenceManager {
    * Set the app version.
    */
   setAppVersion(version: string | null): void {
-    if (isLocalStorageAvailable()) {
+    if (this.shouldUseLocalStorage()) {
       if (version) {
         localStorage.setItem(APP_VERSION_KEY, version);
       } else {
@@ -446,7 +480,7 @@ class PersistenceManager {
   isFirstLaunch(): boolean {
     const FIRST_LAUNCH_KEY = 'mostlygoodmetrics_installed';
 
-    if (!isLocalStorageAvailable()) {
+    if (!this.shouldUseLocalStorage()) {
       return false; // Can't reliably detect without persistence
     }
 
@@ -462,7 +496,7 @@ class PersistenceManager {
    * Get all super properties.
    */
   getSuperProperties(): EventProperties {
-    if (isLocalStorageAvailable()) {
+    if (this.shouldUseLocalStorage()) {
       try {
         const stored = localStorage.getItem(SUPER_PROPERTIES_KEY);
         if (stored) {
@@ -512,7 +546,7 @@ class PersistenceManager {
 
   private saveSuperProperties(properties: EventProperties): void {
     this.inMemorySuperProperties = properties;
-    if (isLocalStorageAvailable()) {
+    if (this.shouldUseLocalStorage()) {
       try {
         localStorage.setItem(SUPER_PROPERTIES_KEY, JSON.stringify(properties));
       } catch (e) {
@@ -525,49 +559,117 @@ class PersistenceManager {
    * Get the stored identify hash (for debouncing).
    */
   getIdentifyHash(): string | null {
-    if (isLocalStorageAvailable()) {
+    if (this.shouldUseLocalStorage()) {
       return localStorage.getItem(IDENTIFY_HASH_KEY);
     }
-    return null;
+    return this.inMemoryIdentifyHash;
   }
 
   /**
    * Set the identify hash.
    */
   setIdentifyHash(hash: string): void {
-    if (isLocalStorageAvailable()) {
+    if (this.shouldUseLocalStorage()) {
       localStorage.setItem(IDENTIFY_HASH_KEY, hash);
     }
+    this.inMemoryIdentifyHash = hash;
   }
 
   /**
    * Get the timestamp of the last identify event sent.
    */
   getIdentifyLastSentAt(): number | null {
-    if (isLocalStorageAvailable()) {
+    if (this.shouldUseLocalStorage()) {
       const timestamp = localStorage.getItem(IDENTIFY_TIMESTAMP_KEY);
       return timestamp ? parseInt(timestamp, 10) : null;
     }
-    return null;
+    return this.inMemoryIdentifyLastSentAt;
   }
 
   /**
    * Set the timestamp of the last identify event sent.
    */
   setIdentifyLastSentAt(timestamp: number): void {
-    if (isLocalStorageAvailable()) {
+    if (this.shouldUseLocalStorage()) {
       localStorage.setItem(IDENTIFY_TIMESTAMP_KEY, timestamp.toString());
     }
+    this.inMemoryIdentifyLastSentAt = timestamp;
   }
 
   /**
    * Clear identify debounce state (used when resetting identity).
    */
   clearIdentifyState(): void {
-    if (isLocalStorageAvailable()) {
+    if (this.shouldUseLocalStorage()) {
       localStorage.removeItem(IDENTIFY_HASH_KEY);
       localStorage.removeItem(IDENTIFY_TIMESTAMP_KEY);
     }
+    this.inMemoryIdentifyHash = null;
+    this.inMemoryIdentifyLastSentAt = null;
+  }
+
+  /**
+   * Get the persisted opt-out choice.
+   * Returns true (opted out), false (explicitly opted in), or null when the
+   * user has never made an explicit choice.
+   */
+  getOptOutStatus(): boolean | null {
+    // Check cookies first (consistent with anonymous ID persistence)
+    if (this.shouldUseCookies()) {
+      const cookieValue = getCookie(OPT_OUT_KEY);
+      if (cookieValue === 'true') {
+        return true;
+      }
+      if (cookieValue === 'false') {
+        return false;
+      }
+    }
+
+    if (this.shouldUseLocalStorage()) {
+      try {
+        const stored = localStorage.getItem(OPT_OUT_KEY);
+        if (stored === 'true') {
+          return true;
+        }
+        if (stored === 'false') {
+          return false;
+        }
+      } catch (e) {
+        logger.warn('Failed to read opt-out status from localStorage', e);
+      }
+    }
+
+    // Only consult the in-memory value when no durable storage is usable
+    // (memory mode or non-browser environments). When durable storage is
+    // available but empty, the user has made no persisted choice.
+    if (!this.shouldUseCookies() && !this.shouldUseLocalStorage()) {
+      return this.inMemoryOptOut;
+    }
+
+    return null;
+  }
+
+  /**
+   * Persist the user's explicit opt-out choice.
+   * Both states are stored so an explicit optIn() overrides
+   * `optedOutByDefault` and Do Not Track defaults on later visits.
+   */
+  setOptOutStatus(optedOut: boolean): void {
+    const value = optedOut ? 'true' : 'false';
+
+    if (this.shouldUseCookies()) {
+      setCookie(OPT_OUT_KEY, value, this.cookieDomain);
+    }
+
+    if (this.shouldUseLocalStorage()) {
+      try {
+        localStorage.setItem(OPT_OUT_KEY, value);
+      } catch (e) {
+        logger.warn('Failed to persist opt-out status to localStorage', e);
+      }
+    }
+
+    this.inMemoryOptOut = optedOut;
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -109,9 +109,50 @@ export interface MGMConfiguration {
    * Disable cookie storage entirely.
    * When true, only localStorage will be used (no cross-subdomain tracking).
    * Useful for GDPR compliance or privacy-focused applications.
+   * Alias for `persistence: 'localStorage'`; ignored when `persistence` is set.
    * @default false
    */
   disableCookies?: boolean;
+
+  /**
+   * Where the SDK persists its state (anonymous ID, event queue, super
+   * properties, opt-out flag, ...):
+   * - `'localStorage+cookie'`: localStorage plus a cookie for the anonymous ID
+   *   (enables cross-subdomain tracking). The default.
+   * - `'localStorage'`: localStorage only, no cookies (same as
+   *   `disableCookies: true`).
+   * - `'memory'`: nothing is written to localStorage or cookies; all state is
+   *   held in memory and lost on reload. For consent-first or cookieless sites.
+   * @default 'localStorage+cookie'
+   */
+  persistence?: PersistenceMode;
+
+  /**
+   * Start opted out of tracking until `optIn()` is called.
+   * Useful for consent-first sites: configure the SDK up front, then call
+   * `optIn()` once the user consents. A previously persisted opt-in/opt-out
+   * choice (from `optIn()`/`optOut()`) takes precedence over this default.
+   * @default false
+   */
+  optedOutByDefault?: boolean;
+
+  /**
+   * Respect the browser's privacy signals. When true, the SDK treats
+   * `navigator.doNotTrack === '1'` or `navigator.globalPrivacyControl === true`
+   * as opted out from initialization. An explicit persisted `optIn()` choice
+   * takes precedence.
+   * @default false
+   */
+  respectDoNotTrack?: boolean;
+
+  /**
+   * Collect device/browser properties and locale context.
+   * When false, `$device_type` and `$device_model` are omitted from event
+   * properties and `locale`/`timezone` are omitted from events and context.
+   * Platform, OS version and app version are still sent.
+   * @default true
+   */
+  collectDeviceProperties?: boolean;
 
   /**
    * Custom storage adapter. If not provided, uses localStorage in browsers
@@ -288,6 +329,26 @@ export interface MGMEventsPayload {
  * Supported platforms (the actual OS/runtime).
  */
 export type Platform = 'web' | 'ios' | 'android' | 'node';
+
+/**
+ * Where the SDK persists its state.
+ * @see MGMConfiguration.persistence
+ */
+export type PersistenceMode = 'localStorage+cookie' | 'localStorage' | 'memory';
+
+/**
+ * Options for resetIdentity().
+ */
+export interface ResetIdentityOptions {
+  /**
+   * Full "forget me": in addition to clearing the user ID and identify
+   * debounce state, also rotate the anonymous ID, purge queued (unsent)
+   * events, clear super properties and clear the cached experiment
+   * variants/exposures.
+   * @default false
+   */
+  clearAnonymousId?: boolean;
+}
 
 /**
  * SDK identifiers.
@@ -514,6 +575,10 @@ export const DefaultConfiguration = {
   maxStoredEvents: 10000,
   enableDebugLogging: false,
   trackAppLifecycleEvents: false,
+  persistence: 'localStorage+cookie' as PersistenceMode,
+  optedOutByDefault: false,
+  respectDoNotTrack: false,
+  collectDeviceProperties: true,
 } as const;
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -210,6 +210,13 @@ export function resolveConfiguration(config: MGMConfiguration): ResolvedConfigur
     platform: config.platform ?? detectPlatform(),
     sdk: config.sdk ?? 'javascript',
     sdkVersion: config.sdkVersion ?? '',
+    persistence:
+      config.persistence ??
+      (config.disableCookies ? 'localStorage' : DefaultConfiguration.persistence),
+    optedOutByDefault: config.optedOutByDefault ?? DefaultConfiguration.optedOutByDefault,
+    respectDoNotTrack: config.respectDoNotTrack ?? DefaultConfiguration.respectDoNotTrack,
+    collectDeviceProperties:
+      config.collectDeviceProperties ?? DefaultConfiguration.collectDeviceProperties,
     storage: config.storage,
     networkClient: config.networkClient,
     experimentStorage: config.experimentStorage,
@@ -334,6 +341,33 @@ export function getDeviceModel(): string {
   }
 
   return '';
+}
+
+/**
+ * Check whether the browser is signalling a tracking opt-out via
+ * Do Not Track (`navigator.doNotTrack === '1'`) or Global Privacy Control
+ * (`navigator.globalPrivacyControl === true`).
+ * Only honored when the `respectDoNotTrack` configuration option is enabled.
+ */
+export function isDoNotTrackEnabled(): boolean {
+  if (typeof navigator === 'undefined') {
+    return false;
+  }
+
+  const nav = navigator as Navigator & {
+    doNotTrack?: string | null;
+    globalPrivacyControl?: boolean;
+  };
+
+  if (nav.doNotTrack === '1') {
+    return true;
+  }
+
+  if (nav.globalPrivacyControl === true) {
+    return true;
+  }
+
+  return false;
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds a full set of privacy controls to the JavaScript SDK:

- **`optOut()` / `optIn()` / `isOptedOut()`** (instance + static): opting out immediately stops tracking (`track`/`identify`/`flush` become no-ops), purges any queued unsent events, and blocks all network requests including experiment fetches. The choice is persisted via localStorage + cookie (consistent with the anonymous ID) and survives reloads. An explicit `optIn()` is persisted too, so it overrides the defaults below on later visits.
- **`optedOutByDefault`** config (default `false`): start opted out until `optIn()` is called - for consent-first sites. A previously persisted explicit choice wins.
- **`respectDoNotTrack`** config (default `false`): when enabled, `navigator.doNotTrack === '1'` or `navigator.globalPrivacyControl === true` is treated as opted-out from init. Not persisted, so clearing the browser signal re-enables tracking.
- **`resetAnonymousId()`** (now public, instance + static): rotates and persists a fresh anonymous ID, returns it.
- **`resetIdentity({ clearAnonymousId: true })`**: full "forget me" - additionally rotates the anonymous ID, purges queued events, super properties (incl. `$experiment_*`), identify debounce state, and the cached experiment variants/exposure flags, then refetches experiments for the fresh identity. Plain `resetIdentity()` is unchanged.
- **`collectDeviceProperties`** config (default `true`): when `false`, omits `$device_type`/`$device_model` from properties and `locale`/`timezone` from events and batch context. `platform`/`os_version`/`app_version` still sent.
- **`persistence`** config: `'localStorage+cookie'` (default) | `'localStorage'` | `'memory'`. Memory mode writes nothing to localStorage or cookies - anonymous ID, event queue, super properties, opt-out flag and experiment cache are all in-memory only. `disableCookies: true` keeps working as an alias for `'localStorage'`; an explicit `persistence` wins.
- README: new **Privacy** section documenting all controls plus what is auto-collected.

## API decisions

- Opt-out also skips the experiments fetch (no network requests at all while opted out); `optIn()` triggers a fetch.
- Precedence for the initial opt-out state: persisted explicit choice > `optedOutByDefault` > DNT/GPC signal (when `respectDoNotTrack`).
- DNT/GPC-derived opt-out is not persisted - only explicit `optOut()`/`optIn()` calls are.
- `optedOutByDefault` alone still persists an anonymous ID; the README recommends combining with `persistence: 'memory'` for strict consent-first setups.
- New public APIs are additive only; `resetIdentity()` gained an optional options parameter (backwards compatible).

## Testing

- `npm test`: 206 tests pass (25 new privacy tests: opt-out purge/no-op/persistence, optedOutByDefault, DNT/GPC honored only when flag on, forget-me clears everything, memory mode persists nothing, collectDeviceProperties payload shape)
- `npm run build`, `npm run lint`, `npm run format:check` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)