### PR TITLE
Add local experiment enrollment mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A lightweight JavaScript/TypeScript SDK for tracking analytics events with [Most
 - [Properties](#properties)
 - [Manual Flush](#manual-flush)
 - [A/B Testing (Experiments)](#ab-testing-experiments)
+- [Local Experiment Enrollment](#local-experiment-enrollment)
 - [Automatic Behavior](#automatic-behavior)
 - [Debug Logging](#debug-logging)
 - [Framework Integration](#framework-integration)
@@ -157,6 +158,8 @@ MostlyGoodMetrics.configure({
 | `storage` | auto-detected | Custom storage adapter (see [Custom Storage](#custom-storage)) |
 | `networkClient` | fetch-based | Custom network client |
 | `experimentStorage` | auto-detected | Custom key-value storage for the experiments cache (see [A/B Testing](#ab-testing-experiments)) |
+| `experimentMode` | `'server'` | `'server'` (server-assigned variants) or `'local'` (on-device bucketing, see [Local Experiment Enrollment](#local-experiment-enrollment)) |
+| `localExperiments` | - | Inline experiment configs for local mode (zero network) |
 
 ## Automatic Events
 
@@ -340,6 +343,65 @@ MostlyGoodMetrics.configure({
 ```
 
 Async adapters are fully supported - cache hydration completes before `ready()` resolves.
+
+## Local Experiment Enrollment
+
+By default, experiment variants are assigned by the server (`experimentMode: 'server'`), which sends the user ID with the experiments request. If you prefer that **no user identifier ever leaves the device** for experiment enrollment, switch to local mode:
+
+```typescript
+MostlyGoodMetrics.configure({
+  apiKey: 'mgm_proj_your_api_key',
+  experimentMode: 'local',
+});
+
+await MostlyGoodMetrics.ready();
+const variant = MostlyGoodMetrics.getVariant('button-color', 'control');
+```
+
+In local mode the SDK fetches only the experiment *configurations* (`GET /v1/experiments/configs` - a list of `{ id, name, variants }` with no user-specific data; the request carries no `user_id` or `anonymous_id`), and assigns the variant on-device.
+
+### Inline mode (zero network)
+
+Provide the configurations inline and the SDK makes no experiments network request at all:
+
+```typescript
+MostlyGoodMetrics.configure({
+  apiKey: 'mgm_proj_your_api_key',
+  experimentMode: 'local',
+  localExperiments: [
+    {
+      id: '7b1e8a90-4c2d-4f6a-9e3b-2a1d5c8f0e71', // experiment UUID from the dashboard
+      name: 'button-color',
+      variants: ['control', 'treatment'],
+    },
+  ],
+});
+```
+
+### The bucketing algorithm
+
+Local assignment is deterministic and identical across all MGM SDKs (Swift, Android, Flutter, JavaScript):
+
+```
+bucket  = first 8 bytes of SHA-256(utf8("<experiment_uuid>:<user_id>"))
+          interpreted as an unsigned big-endian 64-bit integer
+variant = variants[bucket % variants.length]
+```
+
+`user_id` is the identified user ID if `identify()` has been called, otherwise the anonymous ID. Because the bucket value exceeds `Number.MAX_SAFE_INTEGER`, the SDK computes it with `BigInt`. SHA-256 is computed by a small vendored synchronous implementation (no dependencies; works in browsers, Node.js, React Native and Capacitor webviews, where WebCrypto's async `crypto.subtle` is not universally available). The implementation is locked down by golden-vector tests shared across all SDKs.
+
+### Stickiness
+
+The first variant resolved for an experiment is persisted (keyed by experiment UUID) and reused on subsequent `getVariant()` calls and across restarts. **`identify()` never re-buckets**: a user who was assigned `control` anonymously keeps `control` after logging in, even though their effective user ID changed. A persisted variant is only discarded if it no longer exists in the experiment's variants list.
+
+### Exposure tracking
+
+Unchanged from server mode: on a `getVariant()` hit the variant is stored as a `$experiment_{name}` super property and a `$experiment_exposure` event is tracked once per (user, experiment, variant), with the raw experiment name.
+
+### Caveats
+
+- **No cross-device consistency for anonymous users**: bucketing keys on the local effective user ID, and there is no server-side alias resolution. A user who is anonymous on one device and identified on another may see different variants until they are identified everywhere (identified users get consistent variants on every device, for experiments first evaluated after login).
+- **Config changes**: reordering or removing variants changes assignments for new users (existing sticky assignments are kept while the variant still exists).
 
 ## Automatic Behavior
 

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -1,9 +1,10 @@
 import { MostlyGoodMetrics } from './client';
-import { InMemoryEventStorage } from './storage';
+import { InMemoryEventStorage, InMemoryExperimentStorage } from './storage';
 import {
   IExperimentStorage,
   INetworkClient,
   MGMEventsPayload,
+  MGMExperimentConfig,
   ResolvedConfiguration,
   SendResult,
 } from './types';
@@ -1779,6 +1780,218 @@ describe('MostlyGoodMetrics', () => {
         expect(fetchMock).toHaveBeenCalledTimes(1);
         expect(resolved).toBe(true);
       });
+    });
+  });
+
+  describe('local experiment enrollment', () => {
+    const EXPERIMENT_UUID = '7b1e8a90-4c2d-4f6a-9e3b-2a1d5c8f0e71';
+    const MULTI_VARIANT_UUID = '3f9c2d11-8b7a-4e5f-a0c6-91d2e3f4a5b6';
+    const ASSIGNMENTS_KEY = 'mgm_local_experiment_assignments';
+
+    const localExperiments: MGMExperimentConfig[] = [
+      { id: EXPERIMENT_UUID, name: 'button-color', variants: ['control', 'treatment'] },
+      { id: MULTI_VARIANT_UUID, name: 'onboarding-flow', variants: ['a', 'b', 'c'] },
+    ];
+
+    let experimentStorage: InMemoryExperimentStorage;
+    let originalFetch: typeof global.fetch;
+
+    const waitForAsync = () => new Promise((resolve) => setTimeout(resolve, 10));
+
+    beforeEach(() => {
+      experimentStorage = new InMemoryExperimentStorage();
+      originalFetch = global.fetch;
+      localStorage.clear();
+    });
+
+    afterEach(() => {
+      global.fetch = originalFetch;
+      localStorage.clear();
+    });
+
+    const configureLocal = (overrides: Record<string, unknown> = {}) =>
+      MostlyGoodMetrics.configure({
+        apiKey: 'test-key',
+        storage,
+        networkClient,
+        experimentStorage,
+        trackAppLifecycleEvents: false,
+        experimentMode: 'local',
+        anonymousId: 'user_123',
+        localExperiments,
+        ...overrides,
+      });
+
+    it('should default to server experiment mode', () => {
+      MostlyGoodMetrics.configure({
+        apiKey: 'test-key',
+        storage,
+        networkClient,
+        trackAppLifecycleEvents: false,
+      });
+
+      expect(MostlyGoodMetrics.shared?.configuration.experimentMode).toBe('server');
+    });
+
+    it('should make no network requests with inline localExperiments', async () => {
+      const fetchMock = jest.fn();
+      global.fetch = fetchMock as unknown as typeof global.fetch;
+
+      configureLocal();
+      await MostlyGoodMetrics.ready();
+
+      expect(MostlyGoodMetrics.getVariant('button-color')).toBe('control');
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('should assign variants matching the shared golden vectors', async () => {
+      // Vector: 7b1e8a90-... + "user_123" -> bucket 11452140836674321702 -> 'control'
+      configureLocal({ anonymousId: 'user_123' });
+      await MostlyGoodMetrics.ready();
+      expect(MostlyGoodMetrics.getVariant('button-color')).toBe('control');
+      // Vector: 3f9c2d11-... + "user_123" -> bucket 3772238658190659659 -> 'c'
+      expect(MostlyGoodMetrics.getVariant('onboarding-flow')).toBe('c');
+
+      // Vector: 7b1e8a90-... + "$anon_abc123def456" -> 'treatment'
+      MostlyGoodMetrics.reset();
+      configureLocal({
+        anonymousId: '$anon_abc123def456',
+        experimentStorage: new InMemoryExperimentStorage(),
+      });
+      await MostlyGoodMetrics.ready();
+      expect(MostlyGoodMetrics.getVariant('button-color')).toBe('treatment');
+    });
+
+    it('should keep assignments sticky across identify (never re-buckets)', async () => {
+      const fetchMock = jest.fn();
+      global.fetch = fetchMock as unknown as typeof global.fetch;
+
+      configureLocal();
+      await MostlyGoodMetrics.ready();
+
+      expect(MostlyGoodMetrics.getVariant('button-color')).toBe('control');
+
+      // '$anon_abc123def456' would bucket to 'treatment' - but the persisted
+      // assignment must win
+      MostlyGoodMetrics.identify('$anon_abc123def456');
+      await waitForAsync();
+
+      expect(MostlyGoodMetrics.getVariant('button-color')).toBe('control');
+      // Local mode never refetches on identity change either
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('should persist assignments per experiment UUID', async () => {
+      configureLocal();
+      await MostlyGoodMetrics.ready();
+
+      MostlyGoodMetrics.getVariant('button-color');
+      await waitForAsync();
+
+      const raw = experimentStorage.getItem(ASSIGNMENTS_KEY);
+      expect(raw).not.toBeNull();
+      expect(JSON.parse(raw as string)).toEqual({ [EXPERIMENT_UUID]: 'control' });
+    });
+
+    it('should reuse a persisted assignment across restarts', async () => {
+      // Seed the opposite of what bucketing would compute for user_123
+      experimentStorage.setItem(
+        ASSIGNMENTS_KEY,
+        JSON.stringify({ [EXPERIMENT_UUID]: 'treatment' })
+      );
+
+      configureLocal();
+      await MostlyGoodMetrics.ready();
+
+      expect(MostlyGoodMetrics.getVariant('button-color')).toBe('treatment');
+    });
+
+    it('should re-bucket when a persisted variant no longer exists', async () => {
+      experimentStorage.setItem(
+        ASSIGNMENTS_KEY,
+        JSON.stringify({ [EXPERIMENT_UUID]: 'removed-variant' })
+      );
+
+      configureLocal();
+      await MostlyGoodMetrics.ready();
+
+      expect(MostlyGoodMetrics.getVariant('button-color')).toBe('control');
+    });
+
+    it('should fetch identity-free configs when no inline experiments are given', async () => {
+      const fetchMock = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ experiments: localExperiments }),
+      });
+      global.fetch = fetchMock as unknown as typeof global.fetch;
+
+      configureLocal({ localExperiments: undefined });
+      await MostlyGoodMetrics.ready();
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [url, options] = fetchMock.mock.calls[0] as [
+        string,
+        { headers: Record<string, string> },
+      ];
+      // The privacy point of local mode: no user identifiers on the wire
+      expect(url).toBe('https://ingest.mostlygoodmetrics.com/v1/experiments/configs');
+      expect(url).not.toContain('user_id');
+      expect(url).not.toContain('anonymous_id');
+      expect(options.headers.Authorization).toBe('Bearer test-key');
+
+      expect(MostlyGoodMetrics.getVariant('button-color')).toBe('control');
+    });
+
+    it('should serve cached configs without refetching on restart', async () => {
+      const fetchMock = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ experiments: localExperiments }),
+      });
+      global.fetch = fetchMock as unknown as typeof global.fetch;
+
+      configureLocal({ localExperiments: undefined });
+      await MostlyGoodMetrics.ready();
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+
+      // Restart with the same experiment storage: fresh cache, no refetch
+      MostlyGoodMetrics.reset();
+      configureLocal({ localExperiments: undefined });
+      await MostlyGoodMetrics.ready();
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(MostlyGoodMetrics.getVariant('button-color')).toBe('control');
+    });
+
+    it('should track a $experiment_exposure event with the raw experiment name, once', async () => {
+      configureLocal();
+      await MostlyGoodMetrics.ready();
+
+      MostlyGoodMetrics.getVariant('button-color');
+      MostlyGoodMetrics.getVariant('button-color');
+      await waitForAsync();
+
+      const events = await storage.fetchEvents(100);
+      const exposures = events.filter((e) => e.name === '$experiment_exposure');
+      expect(exposures).toHaveLength(1);
+      expect(exposures[0].properties?.['$experiment_name']).toBe('button-color');
+      expect(exposures[0].properties?.['$variant']).toBe('control');
+    });
+
+    it('should set the experiment super property on assignment', async () => {
+      configureLocal();
+      await MostlyGoodMetrics.ready();
+
+      MostlyGoodMetrics.getVariant('button-color');
+
+      expect(MostlyGoodMetrics.getSuperProperties()['$experiment_button_color']).toBe('control');
+    });
+
+    it('should return the fallback for unknown experiments once loaded', async () => {
+      configureLocal();
+      await MostlyGoodMetrics.ready();
+
+      expect(MostlyGoodMetrics.getVariant('nonexistent')).toBeNull();
+      expect(MostlyGoodMetrics.getVariant('nonexistent', 'fallback')).toBe('fallback');
     });
   });
 });

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,9 +1,12 @@
 import { logger, setDebugLogging } from './logger';
 import { createDefaultNetworkClient } from './network';
 import { createDefaultExperimentStorage, createDefaultStorage, persistence } from './storage';
+import { computeExperimentBucket } from './sha256';
 import {
+  CachedExperimentConfigs,
   CachedExperimentVariants,
   EventProperties,
+  ExperimentConfigsResponse,
   ExperimentsResponse,
   IEventStorage,
   IExperimentStorage,
@@ -12,6 +15,7 @@ import {
   MGMEvent,
   MGMEventContext,
   MGMEventsPayload,
+  MGMExperimentConfig,
   ResolvedConfiguration,
   SystemEvents,
   SystemProperties,
@@ -35,6 +39,14 @@ import {
 const FLUSH_DELAY_MS = 100; // Delay between batch sends
 const EXPERIMENTS_CACHE_KEY = 'mgm_experiment_variants';
 const EXPERIMENT_EXPOSURES_KEY = 'mgm_experiment_exposures';
+// Local enrollment mode: cached experiment configs and sticky on-device
+// assignments (keyed by experiment UUID).
+// TODO(privacy-controls merge): when feat/privacy-controls lands,
+// resetAnonymousId() and resetIdentity({ clearAnonymousId: true }) must also
+// clear LOCAL_ASSIGNMENTS_KEY (and the in-memory localAssignments map) so a
+// forgotten user is re-bucketed under their new identity.
+const LOCAL_EXPERIMENT_CONFIGS_KEY = 'mgm_local_experiment_configs';
+const LOCAL_ASSIGNMENTS_KEY = 'mgm_local_experiment_assignments';
 const EXPERIMENTS_REFETCH_INTERVAL_MS = 60 * 60 * 1000; // Background revalidation at most hourly
 const EXPERIMENTS_FETCH_TIMEOUT_MS = 60 * 1000; // Abort hung experiments fetches so they always settle
 const READY_DEFAULT_TIMEOUT_MS = 5000; // Default ready() timeout, unified across all MGM SDKs
@@ -57,6 +69,8 @@ export class MostlyGoodMetrics {
 
   // A/B testing state
   private assignedVariants: Record<string, string> = {}; // Server-assigned variants
+  private localExperimentsByName: Record<string, MGMExperimentConfig> = {}; // Local mode: name -> config
+  private localAssignments: Record<string, string> = {}; // Local mode: experiment UUID -> sticky variant
   private experimentStorage: IExperimentStorage;
   private experimentsLoaded = false;
   private experimentsReadyResolve: (() => void) | null = null;
@@ -391,7 +405,11 @@ export class MostlyGoodMetrics {
     // then they are swapped atomically - never cleared to null mid-session.
     // The refetch includes anonymous_id so the server can honor the
     // "identified wins" aliasing strategy.
-    if (previousUserId !== userId) {
+    //
+    // Local enrollment mode: nothing to do. Experiment configs are
+    // identity-independent, and existing on-device assignments are sticky -
+    // identify() never re-buckets a user.
+    if (previousUserId !== userId && this.config.experimentMode === 'server') {
       logger.debug('User identity changed, refetching experiments');
       this.resetExperimentsReadyPromise();
       void this.fetchExperiments();
@@ -565,8 +583,11 @@ export class MostlyGoodMetrics {
       return fallback;
     }
 
-    // Check if we have a server-assigned variant for this experiment
-    const variant = this.assignedVariants[experimentName];
+    // Resolve the variant: server-assigned, or bucketed on-device in local mode
+    const variant =
+      this.config.experimentMode === 'local'
+        ? this.resolveLocalVariant(experimentName)
+        : this.assignedVariants[experimentName];
 
     if (variant) {
       // Store as super property so it's attached to all events
@@ -576,7 +597,7 @@ export class MostlyGoodMetrics {
       // Track exposure once per (user, experiment, variant)
       this.trackExposureIfNeeded(experimentName, variant);
 
-      logger.debug(`Using server-assigned variant '${variant}' for experiment '${experimentName}'`);
+      logger.debug(`Using variant '${variant}' for experiment '${experimentName}'`);
       return variant;
     }
 
@@ -841,6 +862,10 @@ export class MostlyGoodMetrics {
    *    when the fetch settles, even on failure).
    */
   private async initializeExperiments(): Promise<void> {
+    if (this.config.experimentMode === 'local') {
+      return this.initializeLocalExperiments();
+    }
+
     const currentUserId = this.userId ?? this.anonymousIdValue;
 
     // Hydrate exposure flags first so exposure dedup survives restarts
@@ -925,6 +950,222 @@ export class MostlyGoodMetrics {
     } finally {
       clearTimeout(abortTimer);
       this.markExperimentsReady();
+    }
+  }
+
+  // =====================================================
+  // Local enrollment mode (experimentMode: 'local')
+  // =====================================================
+
+  /**
+   * Initialize experiments in local enrollment mode.
+   *
+   * Instead of asking the server for per-user assignments, the SDK loads
+   * identity-free experiment *configurations* and assigns variants on-device
+   * via deterministic hashing (see resolveLocalVariant). No user identifier
+   * ever leaves the device for experiment enrollment.
+   *
+   * Configuration sources, in order:
+   * 1. Inline `localExperiments` from the configuration - zero network.
+   * 2. Cached configs from the experiment storage adapter, served
+   *    immediately and revalidated in the background at most hourly
+   *    (same stale-while-revalidate pattern as server mode).
+   * 3. A fetch of GET /v1/experiments/configs.
+   */
+  private async initializeLocalExperiments(): Promise<void> {
+    // Hydrate exposure flags and sticky assignments so both survive restarts
+    await this.hydrateExposures();
+    await this.hydrateLocalAssignments();
+
+    // Inline configs: no network at all
+    if (this.config.localExperiments) {
+      this.setLocalExperimentConfigs(this.config.localExperiments);
+      logger.debug(`Using ${this.config.localExperiments.length} inline local experiment configs`);
+      this.markExperimentsReady();
+      return;
+    }
+
+    // Cached configs: serve immediately, revalidate in the background
+    const cached = await this.loadLocalConfigsCache();
+    if (cached) {
+      const cacheAge = Date.now() - cached.fetchedAt;
+      logger.debug(
+        `Using cached local experiment configs (age: ${Math.round(cacheAge / 1000 / 60)}min)`
+      );
+      this.setLocalExperimentConfigs(cached.experiments);
+      this.markExperimentsReady();
+
+      if (cacheAge >= EXPERIMENTS_REFETCH_INTERVAL_MS) {
+        logger.debug('Cached local experiment configs are stale, revalidating in background');
+        void this.fetchLocalExperimentConfigs();
+      }
+      return;
+    }
+
+    // No usable cache - fetch from the server
+    await this.fetchLocalExperimentConfigs();
+  }
+
+  /**
+   * Fetch experiment configurations for local enrollment.
+   *
+   * Unlike the server-assignment fetch, this request intentionally carries no
+   * user_id or anonymous_id - that is the privacy point of local mode.
+   * Uses the same auth and abort-timeout behavior as fetchExperiments().
+   */
+  private async fetchLocalExperimentConfigs(): Promise<void> {
+    const url = `${this.config.baseURL}/v1/experiments/configs`;
+
+    const abortController = new AbortController();
+    const abortTimer = setTimeout(() => abortController.abort(), EXPERIMENTS_FETCH_TIMEOUT_MS);
+
+    try {
+      logger.debug('Fetching local experiment configs...');
+
+      const response = await fetch(url, {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${this.config.apiKey}`,
+          'Content-Type': 'application/json',
+        },
+        signal: abortController.signal,
+      });
+
+      if (!response.ok) {
+        logger.warn(`Failed to fetch local experiment configs: ${response.status}`);
+        return;
+      }
+
+      const data = (await response.json()) as ExperimentConfigsResponse;
+      const experiments = data.experiments ?? [];
+
+      this.setLocalExperimentConfigs(experiments);
+      await this.saveLocalConfigsCache(experiments);
+
+      logger.debug(`Loaded ${experiments.length} local experiment configs`);
+    } catch (e) {
+      logger.warn('Failed to fetch local experiment configs', e);
+    } finally {
+      clearTimeout(abortTimer);
+      this.markExperimentsReady();
+    }
+  }
+
+  /**
+   * Index experiment configurations by name for getVariant() lookups.
+   */
+  private setLocalExperimentConfigs(configs: MGMExperimentConfig[]): void {
+    const byName: Record<string, MGMExperimentConfig> = {};
+    for (const config of configs) {
+      byName[config.name] = config;
+    }
+    this.localExperimentsByName = byName;
+  }
+
+  /**
+   * Resolve the variant for an experiment via on-device bucketing.
+   *
+   * Algorithm (shared across all MGM SDKs, locked by golden-vector tests):
+   *   bucket  = first 8 bytes of SHA-256(utf8("<experiment_uuid>:<user_id>"))
+   *             as an unsigned big-endian 64-bit integer (BigInt)
+   *   variant = variants[bucket % variants.length]
+   * where user_id is the identified user ID if set, otherwise the anonymous ID.
+   *
+   * Assignments are sticky: the first resolved variant is persisted per
+   * experiment UUID and reused on later calls and restarts - identify() never
+   * re-buckets. A persisted variant is only discarded if it no longer exists
+   * in the experiment's variants list.
+   */
+  private resolveLocalVariant(experimentName: string): string | null {
+    const config = this.localExperimentsByName[experimentName];
+    if (!config || config.variants.length === 0) {
+      return null;
+    }
+
+    // Sticky assignment: reuse the persisted variant for this experiment UUID
+    const existing = this.localAssignments[config.id];
+    if (existing && config.variants.includes(existing)) {
+      return existing;
+    }
+
+    const effectiveUserId = this.userId ?? this.anonymousIdValue;
+    const bucket = computeExperimentBucket(config.id, effectiveUserId);
+    const variant = config.variants[Number(bucket % BigInt(config.variants.length))];
+
+    this.localAssignments[config.id] = variant;
+    void this.persistLocalAssignments();
+
+    logger.debug(
+      `Locally bucketed variant '${variant}' for experiment '${experimentName}' (bucket ${bucket})`
+    );
+    return variant;
+  }
+
+  /**
+   * Hydrate sticky local assignments from the experiment storage adapter.
+   */
+  private async hydrateLocalAssignments(): Promise<void> {
+    try {
+      const raw = await this.experimentStorage.getItem(LOCAL_ASSIGNMENTS_KEY);
+      if (raw) {
+        const parsed = JSON.parse(raw) as unknown;
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+          const assignments: Record<string, string> = {};
+          for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
+            if (typeof value === 'string') {
+              assignments[key] = value;
+            }
+          }
+          this.localAssignments = assignments;
+        }
+      }
+    } catch (e) {
+      logger.debug('Failed to load local experiment assignments', e);
+    }
+  }
+
+  /**
+   * Persist sticky local assignments via the experiment storage adapter.
+   */
+  private async persistLocalAssignments(): Promise<void> {
+    try {
+      await this.experimentStorage.setItem(
+        LOCAL_ASSIGNMENTS_KEY,
+        JSON.stringify(this.localAssignments)
+      );
+    } catch (e) {
+      logger.debug('Failed to persist local experiment assignments', e);
+    }
+  }
+
+  /**
+   * Load cached local experiment configs from the experiment storage adapter.
+   */
+  private async loadLocalConfigsCache(): Promise<CachedExperimentConfigs | null> {
+    try {
+      const cached = await this.experimentStorage.getItem(LOCAL_EXPERIMENT_CONFIGS_KEY);
+      if (!cached) {
+        return null;
+      }
+      return JSON.parse(cached) as CachedExperimentConfigs;
+    } catch (e) {
+      logger.debug('Failed to load local experiment configs cache', e);
+      return null;
+    }
+  }
+
+  /**
+   * Save local experiment configs via the experiment storage adapter.
+   */
+  private async saveLocalConfigsCache(experiments: MGMExperimentConfig[]): Promise<void> {
+    try {
+      const cached: CachedExperimentConfigs = {
+        experiments,
+        fetchedAt: Date.now(),
+      };
+      await this.experimentStorage.setItem(LOCAL_EXPERIMENT_CONFIGS_KEY, JSON.stringify(cached));
+    } catch (e) {
+      logger.debug('Failed to save local experiment configs cache', e);
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,9 @@ export type {
   UserProfile,
   Experiment,
   ExperimentsResponse,
+  ExperimentMode,
+  MGMExperimentConfig,
+  ExperimentConfigsResponse,
 } from './types';
 
 // Error class
@@ -90,6 +93,9 @@ export {
   getOSVersion,
   getDeviceModel,
 } from './utils';
+
+// Local experiment enrollment (deterministic on-device bucketing)
+export { sha256, utf8Encode, computeExperimentBucket } from './sha256';
 
 // Logger (for debugging)
 export { logger } from './logger';

--- a/src/sha256.test.ts
+++ b/src/sha256.test.ts
@@ -1,0 +1,156 @@
+import { computeExperimentBucket, sha256, utf8Encode } from './sha256';
+
+const toHex = (bytes: Uint8Array): string =>
+  Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+
+describe('utf8Encode', () => {
+  it('should encode ASCII strings', () => {
+    expect(Array.from(utf8Encode('abc'))).toEqual([0x61, 0x62, 0x63]);
+  });
+
+  it('should encode the empty string', () => {
+    expect(utf8Encode('').length).toBe(0);
+  });
+
+  it('should match Node UTF-8 encoding for multi-byte text', () => {
+    const samples = [
+      'user_123',
+      '日本語ユーザー',
+      'chris@nihongo.example',
+      'héllo wörld',
+      'emoji 👩‍👩‍👧‍👦 test',
+      '$anon_abc123def456',
+    ];
+    for (const sample of samples) {
+      expect(Array.from(utf8Encode(sample))).toEqual(Array.from(Buffer.from(sample, 'utf8')));
+    }
+  });
+});
+
+describe('sha256', () => {
+  // FIPS 180-4 / NIST test vectors
+  it('should produce the NIST digest for "abc"', () => {
+    expect(toHex(sha256(utf8Encode('abc')))).toBe(
+      'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad'
+    );
+  });
+
+  it('should produce the NIST digest for the empty message', () => {
+    expect(toHex(sha256(new Uint8Array(0)))).toBe(
+      'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+    );
+  });
+
+  it('should produce the NIST digest for the two-block message', () => {
+    expect(
+      toHex(sha256(utf8Encode('abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq')))
+    ).toBe('248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1');
+  });
+
+  it('should handle messages spanning the 55/56-byte padding boundary', () => {
+    // 55, 56 and 64 byte messages exercise the padding edge cases
+    expect(toHex(sha256(utf8Encode('a'.repeat(55))))).toBe(
+      toHex(sha256(Uint8Array.from(Array(55).fill(0x61))))
+    );
+    const digest56 = toHex(sha256(utf8Encode('a'.repeat(56))));
+    const digest64 = toHex(sha256(utf8Encode('a'.repeat(64))));
+    expect(digest56).toHaveLength(64);
+    expect(digest64).toHaveLength(64);
+    expect(digest56).not.toBe(digest64);
+  });
+});
+
+describe('computeExperimentBucket (golden vectors, shared across all MGM SDKs)', () => {
+  // These vectors are shared with the Swift, Android and Flutter SDKs.
+  // bucket = first 8 bytes of SHA-256(utf8("<experiment_uuid>:<user_id>"))
+  //          as an unsigned big-endian 64-bit integer
+  // variant = variants[bucket % variants.length]
+  const goldenVectors: {
+    experiment_id: string;
+    user_id: string;
+    variants: string[];
+    bucket: string;
+    expected_variant: string;
+  }[] = [
+    {
+      experiment_id: '7b1e8a90-4c2d-4f6a-9e3b-2a1d5c8f0e71',
+      user_id: 'user_123',
+      variants: ['control', 'treatment'],
+      bucket: '11452140836674321702',
+      expected_variant: 'control',
+    },
+    {
+      experiment_id: '7b1e8a90-4c2d-4f6a-9e3b-2a1d5c8f0e71',
+      user_id: '$anon_abc123def456',
+      variants: ['control', 'treatment'],
+      bucket: '10935638356306450407',
+      expected_variant: 'treatment',
+    },
+    {
+      experiment_id: '3f9c2d11-8b7a-4e5f-a0c6-91d2e3f4a5b6',
+      user_id: 'user_123',
+      variants: ['a', 'b', 'c'],
+      bucket: '3772238658190659659',
+      expected_variant: 'c',
+    },
+    {
+      experiment_id: '3f9c2d11-8b7a-4e5f-a0c6-91d2e3f4a5b6',
+      user_id: 'chris@nihongo.example',
+      variants: ['a', 'b', 'c'],
+      bucket: '15293329125595004806',
+      expected_variant: 'b',
+    },
+    {
+      experiment_id: 'c0ffee00-1234-5678-9abc-def012345678',
+      user_id: 'u',
+      variants: ['on', 'off'],
+      bucket: '5314609686893464838',
+      expected_variant: 'on',
+    },
+    {
+      experiment_id: 'c0ffee00-1234-5678-9abc-def012345678',
+      user_id: '日本語ユーザー',
+      variants: ['on', 'off'],
+      bucket: '15854517259962621242',
+      expected_variant: 'on',
+    },
+    {
+      experiment_id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeffff0000',
+      user_id: 'user_with_long_id_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+      variants: ['v1', 'v2', 'v3', 'v4', 'v5'],
+      bucket: '16479651874404423415',
+      expected_variant: 'v1',
+    },
+    {
+      experiment_id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeffff0000',
+      user_id: '',
+      variants: ['v1', 'v2'],
+      bucket: '2902893145859674316',
+      expected_variant: 'v1',
+    },
+  ];
+
+  it.each(goldenVectors)(
+    'vector: experiment $experiment_id, user "$user_id" -> $expected_variant',
+    ({ experiment_id, user_id, variants, bucket, expected_variant }) => {
+      const computedBucket = computeExperimentBucket(experiment_id, user_id);
+
+      // Raw bucket value must match exactly
+      expect(computedBucket.toString()).toBe(bucket);
+
+      // And the derived variant must match
+      const variant = variants[Number(computedBucket % BigInt(variants.length))];
+      expect(variant).toBe(expected_variant);
+    }
+  );
+
+  it('should exceed Number.MAX_SAFE_INTEGER for some vectors (BigInt required)', () => {
+    const bucket = computeExperimentBucket(
+      'aaaaaaaa-bbbb-cccc-dddd-eeeeffff0000',
+      'user_with_long_id_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
+    );
+    expect(bucket > BigInt(Number.MAX_SAFE_INTEGER)).toBe(true);
+  });
+});

--- a/src/sha256.ts
+++ b/src/sha256.ts
@@ -1,0 +1,184 @@
+/**
+ * Minimal synchronous SHA-256 implementation (FIPS 180-4) plus the
+ * deterministic bucketing helper used for local experiment enrollment.
+ *
+ * Why vendored and synchronous?
+ * - The SDK has zero runtime dependencies, so pulling in a hashing library is
+ *   not an option.
+ * - WebCrypto (`crypto.subtle.digest`) is asynchronous and is not available in
+ *   every environment this SDK runs in: React Native's Hermes engine has no
+ *   WebCrypto, and browsers only expose `crypto.subtle` in secure contexts.
+ *   A small synchronous implementation works identically in browsers, Node.js,
+ *   React Native and Capacitor webviews, and keeps `getVariant()` synchronous.
+ *
+ * The bucketing algorithm is shared across all MGM SDKs (Swift, Android,
+ * Flutter, JS) and is locked down by golden-vector tests - do not change it.
+ */
+
+/* eslint-disable no-bitwise -- SHA-256 is inherently bitwise arithmetic */
+
+/**
+ * SHA-256 round constants (first 32 bits of the fractional parts of the cube
+ * roots of the first 64 primes).
+ */
+// prettier-ignore
+const K = new Uint32Array([
+  0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+  0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+  0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+  0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+  0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+  0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+  0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+  0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+]);
+
+function rotr(x: number, n: number): number {
+  return (x >>> n) | (x << (32 - n));
+}
+
+/**
+ * Compute the SHA-256 digest of a byte array.
+ * Returns the 32-byte digest.
+ */
+export function sha256(message: Uint8Array): Uint8Array {
+  const h = new Uint32Array([
+    0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19,
+  ]);
+
+  // Pad the message: append 0x80, zeros, then the 64-bit big-endian bit length
+  const length = message.length;
+  const paddedLength = (((length + 8) >> 6) + 1) << 6; // Multiple of 64 with room for 0x80 + length
+  const padded = new Uint8Array(paddedLength);
+  padded.set(message);
+  padded[length] = 0x80;
+  const view = new DataView(padded.buffer);
+  // Message lengths in this SDK are far below 2^32 bits, but write both words
+  view.setUint32(paddedLength - 8, Math.floor((length * 8) / 0x100000000));
+  view.setUint32(paddedLength - 4, (length * 8) >>> 0);
+
+  const w = new Uint32Array(64);
+
+  for (let offset = 0; offset < paddedLength; offset += 64) {
+    // Message schedule
+    for (let i = 0; i < 16; i++) {
+      w[i] = view.getUint32(offset + i * 4);
+    }
+    for (let i = 16; i < 64; i++) {
+      const s0 = rotr(w[i - 15], 7) ^ rotr(w[i - 15], 18) ^ (w[i - 15] >>> 3);
+      const s1 = rotr(w[i - 2], 17) ^ rotr(w[i - 2], 19) ^ (w[i - 2] >>> 10);
+      w[i] = (w[i - 16] + s0 + w[i - 7] + s1) >>> 0;
+    }
+
+    // Compression
+    let a = h[0];
+    let b = h[1];
+    let c = h[2];
+    let d = h[3];
+    let e = h[4];
+    let f = h[5];
+    let g = h[6];
+    let hh = h[7];
+
+    for (let i = 0; i < 64; i++) {
+      const s1 = rotr(e, 6) ^ rotr(e, 11) ^ rotr(e, 25);
+      const ch = (e & f) ^ (~e & g);
+      const temp1 = (hh + s1 + ch + K[i] + w[i]) >>> 0;
+      const s0 = rotr(a, 2) ^ rotr(a, 13) ^ rotr(a, 22);
+      const maj = (a & b) ^ (a & c) ^ (b & c);
+      const temp2 = (s0 + maj) >>> 0;
+
+      hh = g;
+      g = f;
+      f = e;
+      e = (d + temp1) >>> 0;
+      d = c;
+      c = b;
+      b = a;
+      a = (temp1 + temp2) >>> 0;
+    }
+
+    h[0] = (h[0] + a) >>> 0;
+    h[1] = (h[1] + b) >>> 0;
+    h[2] = (h[2] + c) >>> 0;
+    h[3] = (h[3] + d) >>> 0;
+    h[4] = (h[4] + e) >>> 0;
+    h[5] = (h[5] + f) >>> 0;
+    h[6] = (h[6] + g) >>> 0;
+    h[7] = (h[7] + hh) >>> 0;
+  }
+
+  const digest = new Uint8Array(32);
+  const digestView = new DataView(digest.buffer);
+  for (let i = 0; i < 8; i++) {
+    digestView.setUint32(i * 4, h[i]);
+  }
+  return digest;
+}
+
+/**
+ * Encode a string as UTF-8 bytes.
+ *
+ * Implemented by hand (instead of `TextEncoder`) because older React Native
+ * Hermes runtimes do not ship `TextEncoder`. Matches WHATWG semantics: lone
+ * surrogates are encoded as U+FFFD.
+ */
+export function utf8Encode(str: string): Uint8Array {
+  const out: number[] = [];
+  for (let i = 0; i < str.length; i++) {
+    let codePoint = str.charCodeAt(i);
+
+    if (codePoint >= 0xd800 && codePoint <= 0xdbff) {
+      // High surrogate: combine with the following low surrogate if present
+      const next = i + 1 < str.length ? str.charCodeAt(i + 1) : 0;
+      if (next >= 0xdc00 && next <= 0xdfff) {
+        codePoint = 0x10000 + ((codePoint - 0xd800) << 10) + (next - 0xdc00);
+        i++;
+      } else {
+        codePoint = 0xfffd; // Unpaired surrogate
+      }
+    } else if (codePoint >= 0xdc00 && codePoint <= 0xdfff) {
+      codePoint = 0xfffd; // Unpaired surrogate
+    }
+
+    if (codePoint < 0x80) {
+      out.push(codePoint);
+    } else if (codePoint < 0x800) {
+      out.push(0xc0 | (codePoint >> 6), 0x80 | (codePoint & 0x3f));
+    } else if (codePoint < 0x10000) {
+      out.push(
+        0xe0 | (codePoint >> 12),
+        0x80 | ((codePoint >> 6) & 0x3f),
+        0x80 | (codePoint & 0x3f)
+      );
+    } else {
+      out.push(
+        0xf0 | (codePoint >> 18),
+        0x80 | ((codePoint >> 12) & 0x3f),
+        0x80 | ((codePoint >> 6) & 0x3f),
+        0x80 | (codePoint & 0x3f)
+      );
+    }
+  }
+  return Uint8Array.from(out);
+}
+
+/**
+ * Compute the deterministic experiment bucket for a (experiment, user) pair.
+ *
+ * bucket = first 8 bytes of SHA-256(utf8("<experiment_uuid>:<user_id>"))
+ * interpreted as an unsigned big-endian 64-bit integer.
+ *
+ * The value exceeds Number.MAX_SAFE_INTEGER, so it is returned as a BigInt.
+ * The variant is then `variants[bucket % variants.length]`.
+ *
+ * This algorithm is shared across all MGM SDKs - do not change it.
+ */
+export function computeExperimentBucket(experimentId: string, userId: string): bigint {
+  const digest = sha256(utf8Encode(`${experimentId}:${userId}`));
+  let bucket = 0n;
+  for (let i = 0; i < 8; i++) {
+    bucket = (bucket << 8n) | BigInt(digest[i]);
+  }
+  return bucket;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -134,6 +134,25 @@ export interface MGMConfiguration {
   experimentStorage?: IExperimentStorage;
 
   /**
+   * How experiment variants are assigned:
+   * - `'server'` (default): the server assigns variants per user
+   *   (`GET /v1/experiments?user_id=...`).
+   * - `'local'`: experiment configurations are loaded without sending any
+   *   user identifier, and variants are assigned on-device via deterministic
+   *   hashing. See `localExperiments` to skip the network entirely.
+   * @default 'server'
+   */
+  experimentMode?: ExperimentMode;
+
+  /**
+   * Inline experiment configurations for `experimentMode: 'local'`.
+   * When provided, the SDK performs no experiments network request at all -
+   * variants are assigned on-device from these configurations.
+   * Ignored in `'server'` mode.
+   */
+  localExperiments?: MGMExperimentConfig[];
+
+  /**
    * Callback invoked when a network error occurs.
    * Useful for reporting errors to external services like Sentry.
    * @param error The error that occurred
@@ -154,12 +173,14 @@ export interface ResolvedConfiguration extends Required<
     | 'anonymousId'
     | 'cookieDomain'
     | 'disableCookies'
+    | 'localExperiments'
   >
 > {
   storage?: IEventStorage;
   networkClient?: INetworkClient;
   experimentStorage?: IExperimentStorage;
   onError?: (error: MGMError) => void;
+  localExperiments?: MGMExperimentConfig[];
 }
 
 /**
@@ -444,6 +465,60 @@ export interface UserProfile {
 }
 
 /**
+ * How experiment variants are assigned.
+ * @see MGMConfiguration.experimentMode
+ */
+export type ExperimentMode = 'server' | 'local';
+
+/**
+ * An experiment configuration used for local (on-device) enrollment.
+ */
+export interface MGMExperimentConfig {
+  /**
+   * The experiment UUID. Used as the stable bucketing key - it must match the
+   * server-side experiment ID so on-device assignments line up across SDKs.
+   */
+  id: string;
+
+  /**
+   * The human-readable experiment name (e.g., "button-color").
+   * This is the key passed to getVariant() and sent on exposure events.
+   */
+  name: string;
+
+  /**
+   * The ordered list of variants (e.g., ["control", "treatment"]).
+   * Order matters: the bucketing algorithm indexes into this array.
+   */
+  variants: string[];
+}
+
+/**
+ * Response from the experiment configs endpoint
+ * (GET /v1/experiments/configs) used in local enrollment mode.
+ * Contains no user-specific data.
+ */
+export interface ExperimentConfigsResponse {
+  experiments: MGMExperimentConfig[];
+}
+
+/**
+ * Cached experiment configurations stored by the experiment storage adapter
+ * in local enrollment mode.
+ */
+export interface CachedExperimentConfigs {
+  /**
+   * The experiment configurations.
+   */
+  experiments: MGMExperimentConfig[];
+
+  /**
+   * Timestamp when the cache was created (ms since epoch).
+   */
+  fetchedAt: number;
+}
+
+/**
  * An experiment configuration from the server.
  */
 export interface Experiment {
@@ -514,6 +589,7 @@ export const DefaultConfiguration = {
   maxStoredEvents: 10000,
   enableDebugLogging: false,
   trackAppLifecycleEvents: false,
+  experimentMode: 'server' as ExperimentMode,
 } as const;
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -210,6 +210,8 @@ export function resolveConfiguration(config: MGMConfiguration): ResolvedConfigur
     platform: config.platform ?? detectPlatform(),
     sdk: config.sdk ?? 'javascript',
     sdkVersion: config.sdkVersion ?? '',
+    experimentMode: config.experimentMode ?? DefaultConfiguration.experimentMode,
+    localExperiments: config.localExperiments,
     storage: config.storage,
     networkClient: config.networkClient,
     experimentStorage: config.experimentStorage,


### PR DESCRIPTION
## Summary

Adds a local (on-device) experiment enrollment mode, matching the API shape already shipped in the Swift (swift#40), Android (android#30) and Flutter (flutter#31) SDKs:

- **`experimentMode: 'server' | 'local'`** (default `'server'` - existing behavior unchanged) and **`localExperiments?: MGMExperimentConfig[]`** (`{ id, name, variants }`).
- **Local mode** fetches `GET /v1/experiments/configs` (same Bearer auth, abort timeout, and stale-while-revalidate hourly caching as the existing experiments fetch). The request carries **no `user_id` or `anonymous_id`** - that is the privacy point. Backend endpoint is in flight; mocked in tests.
- **Inline mode**: providing `localExperiments` makes zero experiments network requests.
- **On-device bucketing**: `bucket = first 8 bytes of SHA-256(utf8("<experiment_uuid>:<effective_user_id>"))` as an **unsigned big-endian 64-bit integer**, `variant = variants[bucket % variants.length]`. Since the bucket exceeds `Number.MAX_SAFE_INTEGER`, it is computed with `BigInt`. `effective_user_id` = identified ID else anonymous ID.
- **SHA-256 choice**: a small vendored **synchronous** SHA-256 + UTF-8 encoder (`src/sha256.ts`). WebCrypto's `crypto.subtle.digest` is async and unavailable on React Native Hermes (and only in secure contexts in browsers); the SDK has zero runtime deps, so a ~150-line sync implementation keeps `getVariant()` synchronous and works identically in browsers, Node, RN and Capacitor. Locked by NIST vectors + the shared golden vectors.
- **Sticky assignments**: persisted per experiment UUID under `mgm_local_experiment_assignments` via the (pluggable) experiment storage adapter; reused across calls and restarts. `identify()` never re-buckets and never refetches in local mode. A persisted variant is only discarded if it no longer exists in the variants list.
- **Exposure events unchanged**: `$experiment_exposure` with the raw experiment name, existing (user, experiment, variant) dedup; `getVariant()` keyed by name via a name→config map.
- README: new "Local Experiment Enrollment" section (algorithm, privacy benefit, cross-device caveat, inline mode).

## Interaction with feat/privacy-controls (#46)

A `TODO(privacy-controls merge)` is noted at the key constants in `client.ts`: when #46 (forget-me / `resetAnonymousId`) and this branch both merge, the full identity reset must also clear `mgm_local_experiment_assignments` (and the in-memory map) so forgotten users are re-bucketed. Both PRs branch off main independently; minor conflicts are expected and fine.

## Golden vectors

All 8 shared cross-SDK vectors are embedded in `src/sha256.test.ts` and assert **both** the raw 64-bit bucket value and the derived variant - including the UTF-8 Japanese user ID (日本語ユーザー) and the empty-string user ID. **All 8 pass.**

## Testing

- `npm ci && npm run build && npm test`: 208 tests pass (28 new: 8 golden vectors + NIST/UTF-8 vectors, inline zero-network, deterministic assignment, sticky-across-identify, persistence + restart reuse, stale-variant re-bucket, identity-free fetch shape, exposure dedup with raw name, super property, fallback, server default)
- `npm run typecheck`, `npm run lint`, `npm run format:check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)