### PR TITLE
MGM-195: include $anonymous_id in $identify event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- The `$identify` event now includes an `$anonymous_id` property set to the user's stored anonymous ID (the ID used for events before `identify()` was called), so the backend can link anonymous events to the newly-identified `user_id`. The event's `user_id` remains the identified ID, and `$anonymous_id` is omitted when there is no distinct anonymous ID (null or equal to the identified ID). (MGM-195)
+
 ## [0.8.0] - 2026-07-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ MostlyGoodMetrics.resetIdentity();
 // After reset: user_id = new auto-generated UUID
 ```
 
+When `identify()` sends a `$identify` event (i.e. when you pass profile data such as `email` or `name`), the event's `properties` include `$anonymous_id` set to the anonymous ID the user had before `identify()` was called. Its `user_id` is the newly-identified ID. This lets the backend link a user's earlier anonymous events to their identified ID. `$anonymous_id` is omitted when there is no distinct anonymous ID (e.g. the anonymous ID already equals the identified ID).
+
 ### Cross-Subdomain Tracking
 
 To track users across subdomains (e.g., `app.example.com` and `blog.example.com`), configure a shared cookie domain:

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -435,17 +435,14 @@ describe('MostlyGoodMetrics', () => {
       const events = await storage.fetchEvents(10);
       const identifyEvent = events.find((e) => e.name === '$identify');
       expect(identifyEvent).toBeDefined();
-      // user_id stays the newly-identified id...
       expect(identifyEvent?.user_id).toBe('user_123');
-      // ...while $anonymous_id carries the stored anonymous id so the backend
-      // can link anonymous -> identified events.
+      // $anonymous_id carries the stored anon id so the backend can link events.
       expect(identifyEvent?.properties?.['$anonymous_id']).toBe(anonymousIdBeforeIdentify);
     });
 
     it('should omit $anonymous_id when the anonymous id equals the identified user id (MGM-195)', async () => {
       const sharedId = 'shared-id-abc';
-      // Reset so we can reconfigure with an anonymous id override that matches
-      // the identified id, leaving no distinct anonymous id to alias.
+      // Reconfigure with an anon id that matches the identified id (nothing to alias).
       MostlyGoodMetrics.reset();
       MostlyGoodMetrics.configure({
         apiKey: 'test-key',

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -420,6 +420,51 @@ describe('MostlyGoodMetrics', () => {
       const identifyEvent = events.find((e) => e.name === '$identify');
       expect(identifyEvent).toBeUndefined();
     });
+
+    it('should include $anonymous_id equal to the pre-identify anonymous id (MGM-195)', async () => {
+      MostlyGoodMetrics.resetIdentity(); // Clear any previous identify state
+
+      // Capture the anonymous id used for events before identify() is called.
+      const anonymousIdBeforeIdentify = MostlyGoodMetrics.shared?.anonymousId;
+      expect(anonymousIdBeforeIdentify).toBeDefined();
+
+      MostlyGoodMetrics.identify('user_123', { email: 'link@example.com' });
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const events = await storage.fetchEvents(10);
+      const identifyEvent = events.find((e) => e.name === '$identify');
+      expect(identifyEvent).toBeDefined();
+      // user_id stays the newly-identified id...
+      expect(identifyEvent?.user_id).toBe('user_123');
+      // ...while $anonymous_id carries the stored anonymous id so the backend
+      // can link anonymous -> identified events.
+      expect(identifyEvent?.properties?.['$anonymous_id']).toBe(anonymousIdBeforeIdentify);
+    });
+
+    it('should omit $anonymous_id when the anonymous id equals the identified user id (MGM-195)', async () => {
+      const sharedId = 'shared-id-abc';
+      // Reset so we can reconfigure with an anonymous id override that matches
+      // the identified id, leaving no distinct anonymous id to alias.
+      MostlyGoodMetrics.reset();
+      MostlyGoodMetrics.configure({
+        apiKey: 'test-key',
+        storage,
+        networkClient,
+        trackAppLifecycleEvents: false,
+        anonymousId: sharedId,
+      });
+      MostlyGoodMetrics.resetIdentity(); // Clear any previous identify state
+
+      MostlyGoodMetrics.identify(sharedId, { email: 'same@example.com' });
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const events = await storage.fetchEvents(10);
+      const identifyEvent = events.find((e) => e.name === '$identify');
+      expect(identifyEvent).toBeDefined();
+      expect(identifyEvent?.properties?.['$anonymous_id']).toBeUndefined();
+    });
   });
 
   describe('resetIdentity', () => {

--- a/src/client.ts
+++ b/src/client.ts
@@ -521,10 +521,7 @@ export class MostlyGoodMetrics {
         properties.name = profile.name;
       }
 
-      // Include the stored anonymous ID so the backend can link the user's
-      // pre-identify (anonymous) events to their newly-identified user_id.
-      // Only send it when a distinct anonymous ID exists - there is no point
-      // aliasing an ID to itself when the anon ID equals the identified user_id.
+      // Send stored anon id (when distinct) so the backend can link pre-identify events.
       const anonymousId = this.anonymousIdValue;
       if (anonymousId && anonymousId !== userId) {
         properties.$anonymous_id = anonymousId;

--- a/src/client.ts
+++ b/src/client.ts
@@ -521,6 +521,15 @@ export class MostlyGoodMetrics {
         properties.name = profile.name;
       }
 
+      // Include the stored anonymous ID so the backend can link the user's
+      // pre-identify (anonymous) events to their newly-identified user_id.
+      // Only send it when a distinct anonymous ID exists - there is no point
+      // aliasing an ID to itself when the anon ID equals the identified user_id.
+      const anonymousId = this.anonymousIdValue;
+      if (anonymousId && anonymousId !== userId) {
+        properties.$anonymous_id = anonymousId;
+      }
+
       // Track the $identify event
       this.track(SystemEvents.IDENTIFY, properties);
 


### PR DESCRIPTION
## Summary

Implements the MGM-195 contract in the JavaScript SDK (the core SDK that React Native and Capacitor wrap).

When the SDK sends the `$identify` event, its `properties` now include `$anonymous_id`, set to the SDK's **stored anonymous id** (the id used for events *before* `identify()` was called). The event's `user_id` stays the newly-identified id. This lets the backend link anonymous → identified events.

`$anonymous_id` is only included when a stored anonymous id exists **and** it differs from the identified `user_id` (skipped when null/equal — no point aliasing an id to itself). Email/name profile handling is unchanged.

## Implementation

- `src/client.ts` — in `sendIdentifyEventIfNeeded()`, add `$anonymous_id` to the `$identify` event properties, sourced from `this.anonymousIdValue` (the client's cached stored anonymous id, initialized from `persistence.initializeAnonymousId()` / equivalent to `persistence.getAnonymousId()`, and the same source already used for the experiments alias URL).
- `src/client.test.ts` — two new tests: (1) `$identify` carries `$anonymous_id` equal to the pre-identify anonymous id while `user_id` stays the identified id; (2) `$anonymous_id` is omitted when the anonymous id equals the identified user id.
- `README.md` / `CHANGELOG.md` — documented the new property.

## Testing

- `npm test` → 243 passed
- `npm run lint` → 0 errors (pre-existing `require-await` warnings in `storage.ts` only)
- `npm run typecheck` → clean
- `npm run build` → succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)